### PR TITLE
Implement Sega Master System FM sound unit

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ Cross-platform multi-console Sega emulator that supports the Sega Genesis / Mega
 
 Major TODOs:
 * Implement a few remaining YM2612 features (CSM and SSG-EG, they're obscure but some games did use them)
-* Support the SMS optional YM2413 FM sound chip
 
 Minor TODOs:
 * Emulate the Genesis VDP FIFO, in particular the fact that the CPU stalls if it performs VRAM writes too rapidly during active display. A few games depend on this to function correctly (e.g. _The Chaos Engine_, _Double Clutch_, _Sol-Deace_), and a few other games have graphical glitches if it's not emulated (e.g. the EA logo flickering for a single frame)

--- a/jgenesis-cli/src/main.rs
+++ b/jgenesis-cli/src/main.rs
@@ -86,8 +86,8 @@ struct Args {
     #[arg(long, default_value_t)]
     sms_crop_left_border: bool,
 
-    /// Enable SMS FM sound unit
-    #[arg(long = "enable-sms-fm-unit", default_value_t)]
+    /// Disable SMS FM sound unit
+    #[arg(long = "disable-sms-fm-unit", default_value_t = true, action = clap::ArgAction::SetFalse)]
     sms_fm_unit_enabled: bool,
 
     /// Disable audio sync

--- a/jgenesis-cli/src/main.rs
+++ b/jgenesis-cli/src/main.rs
@@ -86,6 +86,10 @@ struct Args {
     #[arg(long, default_value_t)]
     sms_crop_left_border: bool,
 
+    /// Enable SMS FM sound unit
+    #[arg(long = "enable-sms-fm-unit", default_value_t)]
+    sms_fm_unit_enabled: bool,
+
     /// Disable audio sync
     #[arg(long = "no-audio-sync", default_value_t = true, action = clap::ArgAction::SetFalse)]
     audio_sync: bool,
@@ -369,6 +373,7 @@ fn run_sms(args: Args) -> anyhow::Result<()> {
         sms_region: args.sms_region,
         sms_crop_vertical_border: args.sms_crop_vertical_border,
         sms_crop_left_border: args.sms_crop_left_border,
+        fm_sound_unit_enabled: args.sms_fm_unit_enabled,
     };
 
     let mut emulator = jgenesis_native_driver::create_smsgg(config.into())?;

--- a/jgenesis-gui/src/app.rs
+++ b/jgenesis-gui/src/app.rs
@@ -230,6 +230,7 @@ enum OpenWindow {
     SmsGgVideo,
     GenesisVideo,
     CommonAudio,
+    SmsGgAudio,
     SmsGgKeyboard,
     SmsGgGamepad,
     GenesisKeyboard,
@@ -674,6 +675,20 @@ impl App {
         let mut open = true;
         Window::new("General Audio Settings").open(&mut open).resizable(false).show(ctx, |ui| {
             ui.checkbox(&mut self.config.common.audio_sync, "Audio sync enabled");
+        });
+        if !open {
+            self.state.open_windows.remove(&OpenWindow::CommonAudio);
+        }
+    }
+
+    fn render_smsgg_audio_settings(&mut self, ctx: &Context) {
+        let mut open = true;
+        Window::new("SMS/GG Audio Settings").open(&mut open).resizable(false).show(ctx, |ui| {
+            ui.set_enabled(self.emu_thread.status() != EmuThreadStatus::RunningSmsGg);
+            ui.checkbox(
+                &mut self.config.smsgg.fm_sound_unit_enabled,
+                "Sega Master System FM sound unit enabled",
+            );
 
             ui.group(|ui| {
                 ui.label("SMS/GG PSG version");
@@ -696,15 +711,9 @@ impl App {
                     .on_hover_text("SMS1 and Game Gear PSGs correctly play high volumes");
                 });
             });
-
-            ui.set_enabled(self.emu_thread.status() != EmuThreadStatus::RunningSmsGg);
-            ui.checkbox(
-                &mut self.config.smsgg.fm_sound_unit_enabled,
-                "Sega Master System FM sound unit enabled",
-            );
         });
         if !open {
-            self.state.open_windows.remove(&OpenWindow::CommonAudio);
+            self.state.open_windows.remove(&OpenWindow::SmsGgAudio);
         }
     }
 
@@ -816,6 +825,11 @@ impl App {
                 ui.menu_button("Audio", |ui| {
                     if ui.button("General").clicked() {
                         self.state.open_windows.insert(OpenWindow::CommonAudio);
+                        ui.close_menu();
+                    }
+
+                    if ui.button("SMS/GG").clicked() {
+                        self.state.open_windows.insert(OpenWindow::SmsGgAudio);
                         ui.close_menu();
                     }
                 });
@@ -1008,6 +1022,9 @@ impl eframe::App for App {
                 }
                 OpenWindow::CommonAudio => {
                     self.render_audio_settings(ctx);
+                }
+                OpenWindow::SmsGgAudio => {
+                    self.render_smsgg_audio_settings(ctx);
                 }
                 OpenWindow::SmsGgKeyboard => {
                     self.render_smsgg_keyboard_settings(ctx);

--- a/jgenesis-gui/src/app.rs
+++ b/jgenesis-gui/src/app.rs
@@ -94,6 +94,8 @@ struct SmsGgAppConfig {
     sms_crop_vertical_border: bool,
     #[serde(default)]
     sms_crop_left_border: bool,
+    #[serde(default)]
+    fm_sound_unit_enabled: bool,
 }
 
 impl Default for SmsGgAppConfig {
@@ -192,6 +194,7 @@ impl AppConfig {
             sms_region: self.smsgg.sms_region,
             sms_crop_vertical_border: self.smsgg.sms_crop_vertical_border,
             sms_crop_left_border: self.smsgg.sms_crop_left_border,
+            fm_sound_unit_enabled: self.smsgg.fm_sound_unit_enabled,
         })
     }
 
@@ -693,6 +696,12 @@ impl App {
                     .on_hover_text("SMS1 and Game Gear PSGs correctly play high volumes");
                 });
             });
+
+            ui.set_enabled(self.emu_thread.status() != EmuThreadStatus::RunningSmsGg);
+            ui.checkbox(
+                &mut self.config.smsgg.fm_sound_unit_enabled,
+                "Sega Master System FM sound unit enabled",
+            );
         });
         if !open {
             self.state.open_windows.remove(&OpenWindow::CommonAudio);

--- a/jgenesis-gui/src/app.rs
+++ b/jgenesis-gui/src/app.rs
@@ -94,7 +94,7 @@ struct SmsGgAppConfig {
     sms_crop_vertical_border: bool,
     #[serde(default)]
     sms_crop_left_border: bool,
-    #[serde(default)]
+    #[serde(default = "true_fn")]
     fm_sound_unit_enabled: bool,
 }
 

--- a/jgenesis-native-driver/src/config.rs
+++ b/jgenesis-native-driver/src/config.rs
@@ -94,6 +94,7 @@ pub struct SmsGgConfig {
     pub sms_region: SmsRegion,
     pub sms_crop_vertical_border: bool,
     pub sms_crop_left_border: bool,
+    pub fm_sound_unit_enabled: bool,
 }
 
 impl SmsGgConfig {
@@ -109,6 +110,7 @@ impl SmsGgConfig {
             sms_region: self.sms_region,
             sms_crop_vertical_border: self.sms_crop_vertical_border,
             sms_crop_left_border: self.sms_crop_left_border,
+            fm_sound_unit_enabled: self.fm_sound_unit_enabled,
         }
     }
 }

--- a/smsgg-core/src/audio.rs
+++ b/smsgg-core/src/audio.rs
@@ -1,0 +1,59 @@
+use bincode::{Decode, Encode};
+use std::collections::VecDeque;
+
+const FIR_COEFFICIENT_0: f64 = -0.003259956981271349;
+const FIR_COEFFICIENTS: [f64; 15] = [
+    -0.003259956981271349,
+    -0.005570469222224621,
+    -0.007089953629792726,
+    0.003470776399922447,
+    0.03855014192816923,
+    0.09860213748863883,
+    0.1654284215535321,
+    0.209868902463026,
+    0.2098689024630259,
+    0.1654284215535322,
+    0.09860213748863887,
+    0.03855014192816925,
+    0.003470776399922449,
+    -0.007089953629792724,
+    -0.005570469222224619,
+];
+
+#[derive(Debug, Clone, Encode, Decode)]
+pub struct LowPassFilter {
+    samples_l: VecDeque<f64>,
+    samples_r: VecDeque<f64>,
+}
+
+impl LowPassFilter {
+    pub fn new() -> Self {
+        Self { samples_l: VecDeque::new(), samples_r: VecDeque::new() }
+    }
+
+    pub fn collect_sample(&mut self, sample_l: f64, sample_r: f64) {
+        self.samples_l.push_back(sample_l);
+        self.samples_r.push_back(sample_r);
+
+        if self.samples_l.len() > FIR_COEFFICIENTS.len() {
+            self.samples_l.pop_front();
+            self.samples_r.pop_front();
+        }
+    }
+
+    pub fn output_sample(&self) -> (f64, f64) {
+        let sample_l = filter_sample(&self.samples_l);
+        let sample_r = filter_sample(&self.samples_r);
+        (sample_l, sample_r)
+    }
+}
+
+fn filter_sample(samples: &VecDeque<f64>) -> f64 {
+    FIR_COEFFICIENT_0
+        + FIR_COEFFICIENTS
+            .iter()
+            .copied()
+            .zip(samples.iter().copied())
+            .map(|(a, b)| a * b)
+            .sum::<f64>()
+}

--- a/smsgg-core/src/lib.rs
+++ b/smsgg-core/src/lib.rs
@@ -1,9 +1,11 @@
 mod api;
+mod audio;
 mod bus;
 mod input;
 mod memory;
 pub mod psg;
 mod vdp;
+mod ym2413;
 
 pub use api::{SmsGgEmulator, SmsGgEmulatorConfig, SmsGgError, SmsGgResult, SmsRegion};
 pub use input::{SmsGgInputs, SmsGgJoypadState};

--- a/smsgg-core/src/memory/metadata.rs
+++ b/smsgg-core/src/memory/metadata.rs
@@ -12,6 +12,7 @@ const SMS_BATTERY_BACKUP_GAMES_CRC32: &[u32] = &[
     0x00bef1d7, // Phantasy Star (U/E) (Rev A)
     0x6605d36a, // Phantasy Star (J)
     0x07301f83, // Phantasy Star (J) (Virtual Console)
+    0xdea82d8e, // Phantasy Star (J) (SMS Power! Retranslation Patch 2.3.1)
     0x75971bef, // Phantasy Star (B)
     0xa1e090b9, // Phantasy Star (World) (Sega Ages)
     0xdf96f194, // Phantasy Star (J) (Sega Ages)

--- a/smsgg-core/src/ym2413.rs
+++ b/smsgg-core/src/ym2413.rs
@@ -712,6 +712,15 @@ impl Ym2413 {
         match self.selected_register {
             register @ 0x00..=0x07 => {
                 self.custom_instrument_patch[register as usize] = value;
+
+                // Immediately reload any channels using custom instrument
+                let end_idx = if self.rhythm_mode_enabled { 6 } else { 9 };
+                for channel in &mut self.channels[..end_idx] {
+                    if channel.settings.instrument == 0 {
+                        channel
+                            .load_instrument(Instrument::from_patch(self.custom_instrument_patch));
+                    }
+                }
             }
             0x0E => {
                 self.handle_rhythm_register_write(value);

--- a/smsgg-core/src/ym2413.rs
+++ b/smsgg-core/src/ym2413.rs
@@ -1,0 +1,945 @@
+use bincode::{Decode, Encode};
+use jgenesis_traits::num::GetBit;
+use std::sync::OnceLock;
+use std::{array, cmp};
+
+// Built-in instrument and rhythm patches from:
+//   https://siliconpr0n.org/archive/doku.php?id=vendor:yamaha:opl2#ym2413_instrument_rom
+const INSTRUMENT_PATCHES: [[u8; 8]; 15] = [
+    [0x71, 0x61, 0x1E, 0x17, 0xD0, 0x78, 0x00, 0x17],
+    [0x13, 0x41, 0x1A, 0x0D, 0xD8, 0xF7, 0x23, 0x13],
+    [0x13, 0x01, 0x99, 0x00, 0xF2, 0xC4, 0x11, 0x23],
+    [0x31, 0x61, 0x0E, 0x07, 0xA8, 0x64, 0x70, 0x27],
+    [0x32, 0x21, 0x1E, 0x06, 0xE0, 0x76, 0x00, 0x28],
+    [0x31, 0x22, 0x16, 0x05, 0xE0, 0x71, 0x00, 0x18],
+    [0x21, 0x61, 0x1D, 0x07, 0x82, 0x81, 0x10, 0x07],
+    [0x23, 0x21, 0x2D, 0x14, 0xA2, 0x72, 0x00, 0x07],
+    [0x61, 0x61, 0x1B, 0x06, 0x64, 0x65, 0x10, 0x17],
+    [0x41, 0x61, 0x0B, 0x18, 0x85, 0xF7, 0x71, 0x07],
+    [0x13, 0x01, 0x83, 0x11, 0xFA, 0xE4, 0x10, 0x04],
+    [0x17, 0xC1, 0x24, 0x07, 0xF8, 0xF8, 0x22, 0x12],
+    [0x61, 0x50, 0x0C, 0x05, 0xC2, 0xF5, 0x20, 0x42],
+    [0x01, 0x01, 0x55, 0x03, 0xC9, 0x95, 0x03, 0x02],
+    [0x61, 0x41, 0x89, 0x03, 0xF1, 0xE4, 0x40, 0x13],
+];
+
+const BASS_DRUM_PATCH: [u8; 8] = [0x01, 0x01, 0x18, 0x0F, 0xDF, 0xF8, 0x6A, 0x6D];
+const SNARE_DRUM_HIGH_HAT_PATCH: [u8; 8] = [0x01, 0x01, 0x00, 0x00, 0xC8, 0xD8, 0xA7, 0x68];
+const TOM_TOM_TOP_CYMBAL_PATCH: [u8; 8] = [0x05, 0x01, 0x00, 0x00, 0xF8, 0xAA, 0x59, 0x55];
+
+// Tables from https://www.smspower.org/Development/YM2413ReverseEngineeringNotes2015-03-20
+const ENVELOPE_INCREMENT_TABLES: [[u8; 8]; 4] = [
+    [0, 1, 0, 1, 0, 1, 0, 1],
+    [0, 1, 0, 1, 1, 1, 0, 1],
+    [0, 1, 1, 1, 0, 1, 1, 1],
+    [0, 1, 1, 1, 1, 1, 1, 1],
+];
+
+// Numbers are multiplied by 2 here - need to divide by 2 after multiplying
+const MULTIPLIER_TABLE: [u32; 16] = [1, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 20, 24, 24, 30, 30];
+
+// Numbers for key_scale_level=3; need to be shifted down for key_scale_level=1 or 2
+const KEY_SCALE_TABLE: [u8; 16] =
+    [0, 48, 64, 74, 80, 86, 90, 94, 96, 100, 102, 104, 106, 108, 110, 112];
+
+#[derive(Debug, Clone, Copy, Default, Encode, Decode)]
+struct OperatorSettings {
+    tremolo: bool,
+    vibrato: bool,
+    sustained_tone: bool,
+    key_scale_rate: bool,
+    key_scale_level: u8,
+    multiple: u8,
+    wave_rectification: bool,
+    attack_rate: u8,
+    decay_rate: u8,
+    sustain_level: u8,
+    release_rate: u8,
+}
+
+#[derive(Debug, Clone, Copy, Default, Encode, Decode)]
+struct ChannelSettings {
+    block: u8,
+    f_number: u16,
+    sustain: bool,
+    instrument: u8,
+    volume: u8,
+    modulator_feedback_level: u8,
+    modulator_total_level: u8,
+}
+
+#[derive(Debug, Clone, Copy, Default, Encode, Decode)]
+struct PhaseGenerator {
+    counter: u32,
+}
+
+const PHASE_COUNTER_MASK: u32 = (1 << 19) - 1;
+const PHASE_MASK: u32 = (1 << 10) - 1;
+
+impl PhaseGenerator {
+    #[inline]
+    fn clock(&mut self, block: u8, f_number: u16, multiple: u8, fm_position: u8, vibrato: bool) {
+        let fm_shift = if vibrato { compute_fm_shift(fm_position, f_number) } else { 0 };
+
+        let phase_shift = (((2 * u32::from(f_number) + fm_shift as u32)
+            * MULTIPLIER_TABLE[multiple as usize])
+            << block)
+            >> 2;
+        self.counter = self.counter.wrapping_add(phase_shift) & PHASE_COUNTER_MASK;
+    }
+}
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Encode, Decode)]
+enum EnvelopePhase {
+    Damp,
+    Attack,
+    Decay,
+    Sustain,
+    #[default]
+    Release,
+}
+
+#[derive(Debug, Clone, Encode, Decode)]
+struct EnvelopeGenerator {
+    operator_type: OperatorType,
+    key_on: bool,
+    attenuation: u8,
+    phase: EnvelopePhase,
+    global_counter: u32,
+}
+
+const MAX_ATTENUATION: u8 = 127;
+
+impl EnvelopeGenerator {
+    fn new(operator_type: OperatorType) -> Self {
+        Self {
+            operator_type,
+            key_on: false,
+            attenuation: MAX_ATTENUATION,
+            phase: EnvelopePhase::Release,
+            global_counter: 0,
+        }
+    }
+
+    fn set_key_on(&mut self, key_on: bool, sustained_tone: bool) {
+        if !self.key_on && key_on {
+            self.phase = EnvelopePhase::Damp;
+        } else if self.key_on && !key_on {
+            self.phase = match (self.operator_type, sustained_tone) {
+                (OperatorType::Carrier, _) | (OperatorType::Modulator, false) => {
+                    EnvelopePhase::Release
+                }
+                (OperatorType::Modulator, true) => EnvelopePhase::Sustain,
+            };
+        }
+        self.key_on = key_on;
+    }
+
+    fn clock(
+        &mut self,
+        operator: OperatorSettings,
+        channel: ChannelSettings,
+        phase_generator: &mut PhaseGenerator,
+        modulator: Option<&mut Operator>,
+    ) {
+        self.global_counter = self.global_counter.wrapping_add(1);
+
+        let sustain_level = operator.sustain_level << 3;
+        let rks = compute_rks(channel.block, channel.f_number, operator.key_scale_rate);
+
+        if self.phase == EnvelopePhase::Damp
+            && self.attenuation >= ENVELOPE_END
+            && self.operator_type == OperatorType::Carrier
+        {
+            if 4 * operator.attack_rate + rks >= 60 {
+                // Skip attack phase if rate is 60-63
+                self.attenuation = 0;
+                self.phase = EnvelopePhase::Decay;
+            } else {
+                self.phase = EnvelopePhase::Attack;
+            };
+            phase_generator.counter = 0;
+
+            if let Some(modulator) = modulator {
+                let modulator_rks =
+                    compute_rks(channel.block, channel.f_number, modulator.settings.key_scale_rate);
+                if 4 * modulator.settings.attack_rate + modulator_rks >= 60 {
+                    modulator.envelope.attenuation = 0;
+                    modulator.envelope.phase = EnvelopePhase::Decay;
+                } else {
+                    modulator.envelope.phase = EnvelopePhase::Attack;
+                }
+                modulator.phase.counter = 0;
+            }
+        }
+
+        if self.phase == EnvelopePhase::Attack && self.attenuation == 0 {
+            self.phase = EnvelopePhase::Decay;
+        }
+
+        if self.phase == EnvelopePhase::Decay && self.attenuation >= sustain_level {
+            self.phase = EnvelopePhase::Sustain;
+        }
+
+        let r = match self.phase {
+            EnvelopePhase::Damp => 12,
+            EnvelopePhase::Attack => operator.attack_rate,
+            EnvelopePhase::Decay => operator.decay_rate,
+            EnvelopePhase::Sustain => {
+                if operator.sustained_tone {
+                    0
+                } else {
+                    operator.release_rate
+                }
+            }
+            EnvelopePhase::Release => {
+                if channel.sustain {
+                    5
+                } else if !operator.sustained_tone {
+                    7
+                } else {
+                    operator.release_rate
+                }
+            }
+        };
+
+        let rate = if r == 0 { 0 } else { cmp::min(63, 4 * r + rks) };
+
+        // Envelope behaviors from:
+        // https://www.smspower.org/Development/YM2413ReverseEngineeringNotes2015-03-20
+        // https://www.smspower.org/Development/YM2413ReverseEngineeringNotes2015-03-27
+        match self.phase {
+            EnvelopePhase::Attack => {
+                match rate {
+                    0..=3 | 60..=63 => {
+                        // Do nothing
+                    }
+                    4..=47 => {
+                        let shift = 13 - (rate >> 2);
+                        let mask = ((1 << shift) - 1) & !0x03;
+                        if self.global_counter & mask == 0 {
+                            let table_idx = (rate & 0x03) as usize;
+                            let increment_idx = ((self.global_counter >> shift) & 0x07) as usize;
+                            let increment = ENVELOPE_INCREMENT_TABLES[table_idx][increment_idx];
+                            if increment == 1 {
+                                self.attenuation -= (self.attenuation >> 4) + 1;
+                            }
+                        }
+                    }
+                    48..=59 => {
+                        let table_idx = (rate & 0x03) as usize;
+                        let increment_idx = ((self.global_counter >> 1) & 0x06) as usize;
+                        let increment = ENVELOPE_INCREMENT_TABLES[table_idx][increment_idx];
+                        let shift = 16 - (rate >> 2) - increment;
+                        self.attenuation -= (self.attenuation >> shift) + 1;
+                    }
+                    _ => panic!("rate must be <= 63"),
+                }
+            }
+            EnvelopePhase::Damp
+            | EnvelopePhase::Decay
+            | EnvelopePhase::Sustain
+            | EnvelopePhase::Release => {
+                match rate {
+                    0..=3 => {
+                        // Do nothing
+                    }
+                    4..=51 => {
+                        let shift = 13 - (rate >> 2);
+                        if self.global_counter & ((1 << shift) - 1) == 0 {
+                            let table_idx = (rate & 0x03) as usize;
+                            let increment_idx = ((self.global_counter >> shift) & 0x07) as usize;
+                            let increment = ENVELOPE_INCREMENT_TABLES[table_idx][increment_idx];
+                            self.attenuation =
+                                cmp::min(MAX_ATTENUATION, self.attenuation + increment);
+                        }
+                    }
+                    52..=55 => {
+                        // Rates 52-55 increment every clock, and each pair of increments gets
+                        // repeated once before moving on to the next pair
+                        let table_idx = (rate & 0x03) as usize;
+                        let increment_idx = (((self.global_counter >> 1) & 0x06)
+                            | (self.global_counter & 0x01))
+                            as usize;
+                        let increment = ENVELOPE_INCREMENT_TABLES[table_idx][increment_idx];
+                        self.attenuation = cmp::min(MAX_ATTENUATION, self.attenuation + increment);
+                    }
+                    56..=59 => {
+                        // Rates 56-59 increment every clock, only use even columns from the table,
+                        // and increment by 1 higher than what's in the table
+                        let table_idx = (rate & 0x03) as usize;
+                        let increment_idx = ((self.global_counter >> 1) & 0x06) as usize;
+                        let increment = ENVELOPE_INCREMENT_TABLES[table_idx][increment_idx] + 1;
+                        self.attenuation = cmp::min(MAX_ATTENUATION, self.attenuation + increment);
+                    }
+                    60..=63 => {
+                        // Always increment by 2
+                        self.attenuation = cmp::min(MAX_ATTENUATION, self.attenuation + 2);
+                    }
+                    _ => panic!("rate should always be <= 63"),
+                }
+            }
+        }
+    }
+}
+
+fn compute_rks(block: u8, f_number: u16, key_scale_rate: bool) -> u8 {
+    ((block << 1) | u8::from(f_number.bit(8))) >> (2 * u8::from(!key_scale_rate))
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Encode, Decode)]
+enum OperatorType {
+    Modulator,
+    Carrier,
+}
+
+#[derive(Debug, Clone, Encode, Decode)]
+struct Operator {
+    settings: OperatorSettings,
+    phase: PhaseGenerator,
+    envelope: EnvelopeGenerator,
+    current_output: i32,
+    prev_output: i32,
+}
+
+// Operators start outputting 0 once attenuation is >= 124 (out of 127)
+const ENVELOPE_END: u8 = 124;
+
+impl Operator {
+    fn new(operator_type: OperatorType) -> Self {
+        Self {
+            settings: OperatorSettings::default(),
+            phase: PhaseGenerator::default(),
+            envelope: EnvelopeGenerator::new(operator_type),
+            current_output: 0,
+            prev_output: 0,
+        }
+    }
+
+    fn set_key_on(&mut self, key_on: bool) {
+        self.envelope.set_key_on(key_on, self.settings.sustained_tone);
+    }
+
+    fn clock(
+        &mut self,
+        channel: ChannelSettings,
+        modulation_input: u32,
+        base_attenuation: u8,
+        am_output: u8,
+        fm_position: u8,
+        modulator: Option<&mut Operator>,
+    ) -> i32 {
+        let block = channel.block;
+        let f_number = channel.f_number;
+
+        self.phase.clock(
+            block,
+            f_number,
+            self.settings.multiple,
+            fm_position,
+            self.settings.vibrato,
+        );
+        self.envelope.clock(self.settings, channel, &mut self.phase, modulator);
+
+        if self.envelope.attenuation >= ENVELOPE_END {
+            self.prev_output = self.current_output;
+            self.current_output = 0;
+            return 0;
+        }
+
+        // Phase counter is 19 bits, log-sin table is a 10-bit loookup
+        let adjusted_phase = (self.phase.counter >> 9).wrapping_add(modulation_input) & PHASE_MASK;
+        let (sine_attenuation, sign) = log_sine_lookup(adjusted_phase);
+
+        let key_scale_level = self.settings.key_scale_level;
+        let key_scale_attenuation = if key_scale_level != 0 {
+            KEY_SCALE_TABLE[(f_number >> 5) as usize].saturating_sub((7 - block) << 4)
+                >> (3 - key_scale_level)
+        } else {
+            0
+        };
+
+        let am_attenuation = if self.settings.tremolo { am_output } else { 0 };
+
+        let total_attenuation = cmp::min(
+            u16::from(MAX_ATTENUATION),
+            u16::from(base_attenuation)
+                + u16::from(key_scale_attenuation)
+                + u16::from(self.envelope.attenuation)
+                + u16::from(am_attenuation),
+        );
+        let amplitude_magnitude = exp2_lookup(sine_attenuation + 16 * total_attenuation);
+
+        let amplitude = match (sign, self.settings.wave_rectification) {
+            (Sign::Positive, _) => i32::from(amplitude_magnitude),
+            (Sign::Negative, false) => -i32::from(amplitude_magnitude),
+            (Sign::Negative, true) => 0,
+        };
+
+        self.prev_output = self.current_output;
+        self.current_output = amplitude;
+        amplitude
+    }
+}
+
+fn compute_fm_shift(fm_position: u8, f_number: u16) -> i16 {
+    // Based on https://www.smspower.org/Development/YM2413ReverseEngineeringNotes2015-12-01
+    let f_num_high_bits = f_number >> 6;
+    let magnitude = match fm_position & 0x03 {
+        0 => 0,
+        1 | 3 => (f_num_high_bits >> 1) as i16,
+        2 => f_num_high_bits as i16,
+        _ => unreachable!("value & 0x03 is always <= 3"),
+    };
+    let sign = if fm_position.bit(3) { -1 } else { 1 };
+    sign * magnitude
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Sign {
+    Positive,
+    Negative,
+}
+
+// Returns the *attenuation* for the given phase, in log2 decibels units
+//   log-sin[i] = -log2(sin((i + 0.5) / 256 * PI/2)) * 256
+// Output range is 0..=2137
+// Source: https://www.smspower.org/Development/YM2413ReverseEngineeringNotes2015-04-09
+fn log_sine_lookup(phase: u32) -> (u16, Sign) {
+    static LOOKUP_TABLE: OnceLock<[(u16, Sign); 1024]> = OnceLock::new();
+    let lookup_table = LOOKUP_TABLE.get_or_init(|| {
+        let quarter_table: [u16; 256] = array::from_fn(|i| {
+            let sine = ((i as f64 + 0.5) / 256.0 * std::f64::consts::PI / 2.0).sin();
+            (-1.0 * sine.log2() * 256.0).round() as u16
+        });
+
+        array::from_fn(|i| match i {
+            0..=255 => (quarter_table[i], Sign::Positive),
+            256..=511 => (quarter_table[255 - (i & 0xFF)], Sign::Positive),
+            512..=767 => (quarter_table[i & 0xFF], Sign::Negative),
+            768..=1023 => (quarter_table[255 - (i & 0xFF)], Sign::Negative),
+            _ => unreachable!("array::from_fn with array of size 1024"),
+        })
+    });
+    lookup_table[phase as usize]
+}
+
+// Returns a 12-bit unsigned amplitude, assuming the input is an attenuation in log2 decibels units
+// Output range is 0..=4084
+// Source: https://www.smspower.org/Development/YM2413ReverseEngineeringNotes2015-04-09
+#[allow(clippy::items_after_statements)]
+fn exp2_lookup(attenuation: u16) -> u16 {
+    let [attenuation_lsb, attenuation_msb] = attenuation.to_le_bytes();
+
+    if attenuation_msb >= 16 {
+        return 0;
+    }
+
+    static LOOKUP_TABLE: OnceLock<[u16; 256]> = OnceLock::new();
+    let lookup_table = LOOKUP_TABLE.get_or_init(|| {
+        array::from_fn(|i| (2.0_f64.powf((255 - i) as f64 / 256.0) * 1024.0).round() as u16 - 1024)
+    });
+    ((lookup_table[attenuation_lsb as usize] + 1024) << 1) >> attenuation_msb
+}
+
+fn compute_amplitude(attenuation: u16, sign: Sign) -> i32 {
+    let magnitude = exp2_lookup(attenuation);
+    match sign {
+        Sign::Positive => magnitude.into(),
+        Sign::Negative => -i32::from(magnitude),
+    }
+}
+
+#[derive(Debug, Clone, Encode, Decode)]
+struct Channel {
+    modulator: Operator,
+    carrier: Operator,
+    settings: ChannelSettings,
+    // Used for tom-tom
+    modulator_volume_override: Option<u8>,
+}
+
+impl Default for Channel {
+    fn default() -> Self {
+        Self {
+            modulator: Operator::new(OperatorType::Modulator),
+            carrier: Operator::new(OperatorType::Carrier),
+            settings: ChannelSettings::default(),
+            modulator_volume_override: None,
+        }
+    }
+}
+
+impl Channel {
+    fn write_register_1(&mut self, value: u8) {
+        self.settings.f_number = (self.settings.f_number & 0xFF00) | u16::from(value);
+
+        log::trace!("F-number: {:03X}", self.settings.f_number);
+    }
+
+    fn write_register_2(&mut self, value: u8) {
+        self.settings.f_number = (self.settings.f_number & 0x00FF) | (u16::from(value & 0x01) << 8);
+        self.settings.block = (value >> 1) & 0x07;
+        self.settings.sustain = value.bit(5);
+
+        log::trace!(
+            "F-number: {:03X}, Block: {}, Channel Sustain: {}",
+            self.settings.f_number,
+            self.settings.block,
+            self.settings.sustain
+        );
+
+        self.set_key_on(value.bit(4));
+    }
+
+    fn write_register_3(&mut self, value: u8) {
+        self.settings.volume = value & 0x0F;
+        self.settings.instrument = value >> 4;
+
+        log::trace!(
+            "Volume: {:02X}, Instrument: {}",
+            self.settings.volume,
+            self.settings.instrument
+        );
+    }
+
+    fn set_key_on(&mut self, key_on: bool) {
+        if self.modulator.envelope.key_on != key_on {
+            log::trace!("State at key on ({key_on}): {self:?}");
+        }
+
+        self.modulator.set_key_on(key_on);
+        self.carrier.set_key_on(key_on);
+    }
+
+    fn reload_instrument(&mut self, custom_instrument_patch: [u8; 8]) {
+        let instrument_idx = self.settings.instrument;
+        let instrument = match instrument_idx {
+            0 => Instrument::from_patch(custom_instrument_patch),
+            _ => Instrument::from_patch(INSTRUMENT_PATCHES[(instrument_idx - 1) as usize]),
+        };
+
+        self.load_instrument(instrument);
+    }
+
+    fn load_instrument(&mut self, instrument: Instrument) {
+        self.modulator.settings = instrument.modulator;
+        self.carrier.settings = instrument.carrier;
+        self.settings.modulator_feedback_level = instrument.modulator_feedback_level;
+        self.settings.modulator_total_level = instrument.modulator_total_level;
+    }
+
+    fn clock(&mut self, am_output: u8, fm_position: u8) {
+        let modulation_feedback = match self.settings.modulator_feedback_level {
+            0 => 0,
+            feedback_level => {
+                (self.modulator.prev_output + self.modulator.current_output) >> (9 - feedback_level)
+            }
+        };
+        let modulator_base_attenuation =
+            self.modulator_volume_override.unwrap_or(self.settings.modulator_total_level << 1);
+        let modulator_output = self.modulator.clock(
+            self.settings,
+            modulation_feedback as u32,
+            modulator_base_attenuation,
+            am_output,
+            fm_position,
+            None,
+        );
+
+        self.carrier.clock(
+            self.settings,
+            modulator_output as u32,
+            self.settings.volume << 3,
+            am_output,
+            fm_position,
+            Some(&mut self.modulator),
+        );
+    }
+
+    fn sample(&self) -> i32 {
+        self.carrier.current_output >> 4
+    }
+}
+
+struct Instrument {
+    modulator: OperatorSettings,
+    carrier: OperatorSettings,
+    modulator_feedback_level: u8,
+    modulator_total_level: u8,
+}
+
+impl Instrument {
+    fn from_patch(patch: [u8; 8]) -> Self {
+        Self {
+            modulator: OperatorSettings {
+                tremolo: patch[0].bit(7),
+                vibrato: patch[0].bit(6),
+                sustained_tone: patch[0].bit(5),
+                key_scale_rate: patch[0].bit(4),
+                key_scale_level: patch[2] >> 6,
+                multiple: patch[0] & 0x0F,
+                wave_rectification: patch[3].bit(3),
+                attack_rate: patch[4] >> 4,
+                decay_rate: patch[4] & 0x0F,
+                sustain_level: patch[6] >> 4,
+                release_rate: patch[6] & 0x0F,
+            },
+            carrier: OperatorSettings {
+                tremolo: patch[1].bit(7),
+                vibrato: patch[1].bit(6),
+                sustained_tone: patch[1].bit(5),
+                key_scale_rate: patch[1].bit(4),
+                key_scale_level: patch[3] >> 6,
+                multiple: patch[1] & 0x0F,
+                wave_rectification: patch[3].bit(4),
+                attack_rate: patch[5] >> 4,
+                decay_rate: patch[5] & 0x0F,
+                sustain_level: patch[7] >> 4,
+                release_rate: patch[7] & 0x0F,
+            },
+            modulator_feedback_level: patch[3] & 0x07,
+            modulator_total_level: patch[2] & 0x3F,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Encode, Decode)]
+struct AmUnit {
+    position: u8,
+    divider: u8,
+}
+
+const AM_DIVIDER: u8 = 64;
+const AM_POSITIONS: u8 = 210;
+
+impl AmUnit {
+    fn new() -> Self {
+        Self { position: 0, divider: AM_DIVIDER }
+    }
+
+    fn clock(&mut self) {
+        self.divider -= 1;
+        if self.divider == 0 {
+            self.divider = AM_DIVIDER;
+            self.position = (self.position + 1) % AM_POSITIONS;
+        }
+    }
+
+    fn output(&self) -> u8 {
+        // Based on https://www.smspower.org/Development/YM2413ReverseEngineeringNotes2015-11-28
+        match self.position {
+            0..=2 => 0,
+            3..=109 => (self.position - 3) >> 3,
+            110..=209 => 12 - ((self.position - 110) >> 3),
+            _ => panic!("AM position must be <= 209"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Encode, Decode)]
+struct FmUnit {
+    position: u8,
+    divider: u16,
+}
+
+const FM_DIVIDER: u16 = 1024;
+const FM_POSITIONS: u8 = 8;
+
+impl FmUnit {
+    fn new() -> Self {
+        Self { position: 0, divider: FM_DIVIDER }
+    }
+
+    fn clock(&mut self) {
+        self.divider -= 1;
+        if self.divider == 0 {
+            self.divider = FM_DIVIDER;
+            self.position = (self.position + 1) % FM_POSITIONS;
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, Encode, Decode)]
+struct RhythmSettings {
+    snare_drum_volume: u8,
+    snare_drum_on: bool,
+    tom_tom_volume: u8,
+    tom_tom_on: bool,
+    top_cymbal_volume: u8,
+    top_cymbal_on: bool,
+    high_hat_volume: u8,
+    high_hat_on: bool,
+}
+
+#[derive(Debug, Clone, Encode, Decode)]
+pub struct Ym2413 {
+    channels: [Channel; 9],
+    rhythm_mode_enabled: bool,
+    rhythm_settings: RhythmSettings,
+    lfsr: u32,
+    am_unit: AmUnit,
+    fm_unit: FmUnit,
+    selected_register: u8,
+    custom_instrument_patch: [u8; 8],
+    divider: u8,
+}
+
+const YM2413_DIVIDER: u8 = 72;
+const MAX_CARRIER_OUTPUT: f64 = 255.0;
+
+impl Ym2413 {
+    pub fn new() -> Self {
+        Self {
+            channels: array::from_fn(|_| Channel::default()),
+            rhythm_mode_enabled: false,
+            rhythm_settings: RhythmSettings::default(),
+            lfsr: 1,
+            am_unit: AmUnit::new(),
+            fm_unit: FmUnit::new(),
+            selected_register: 0,
+            custom_instrument_patch: [0; 8],
+            divider: YM2413_DIVIDER,
+        }
+    }
+
+    pub fn select_register(&mut self, register: u8) {
+        self.selected_register = register;
+    }
+
+    pub fn write_data(&mut self, value: u8) {
+        log::trace!("Write to register {:02X}: {value:02X}", self.selected_register);
+
+        match self.selected_register {
+            register @ 0x00..=0x07 => {
+                self.custom_instrument_patch[register as usize] = value;
+            }
+            0x0E => {
+                self.handle_rhythm_register_write(value);
+            }
+            register @ 0x10..=0x18 => {
+                let channel = register & 0x0F;
+                self.channels[channel as usize].write_register_1(value);
+            }
+            register @ 0x20..=0x28 => {
+                let channel = register & 0x0F;
+                self.channels[channel as usize].write_register_2(value);
+            }
+            register @ 0x30..=0x38 => {
+                let channel = register & 0x0F;
+                self.channels[channel as usize].write_register_3(value);
+
+                if channel < 6 || !self.rhythm_mode_enabled {
+                    self.channels[channel as usize].reload_instrument(self.custom_instrument_patch);
+                }
+
+                // Rhythm volume writes
+                match channel {
+                    // No need to special case bass drum volume; it uses channel 6 volume normally
+                    7 => {
+                        self.rhythm_settings.high_hat_volume = value >> 4;
+                        self.rhythm_settings.snare_drum_volume = value & 0x0F;
+                    }
+                    8 => {
+                        let tom_tom_volume = value >> 4;
+                        self.rhythm_settings.tom_tom_volume = tom_tom_volume;
+                        self.rhythm_settings.top_cymbal_volume = value & 0x0F;
+
+                        if self.rhythm_mode_enabled {
+                            self.channels[8].modulator_volume_override = Some(tom_tom_volume << 3);
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn handle_rhythm_register_write(&mut self, value: u8) {
+        let rhythm_mode_enabled = value.bit(5);
+        if rhythm_mode_enabled != self.rhythm_mode_enabled {
+            if rhythm_mode_enabled {
+                self.channels[6].load_instrument(Instrument::from_patch(BASS_DRUM_PATCH));
+                self.channels[7].load_instrument(Instrument::from_patch(SNARE_DRUM_HIGH_HAT_PATCH));
+                self.channels[8].load_instrument(Instrument::from_patch(TOM_TOM_TOP_CYMBAL_PATCH));
+
+                self.channels[8].modulator_volume_override =
+                    Some(self.rhythm_settings.tom_tom_volume);
+            } else {
+                self.channels[6].reload_instrument(self.custom_instrument_patch);
+                self.channels[7].reload_instrument(self.custom_instrument_patch);
+                self.channels[8].reload_instrument(self.custom_instrument_patch);
+
+                self.channels[8].modulator_volume_override = None;
+
+                // TODO not sure this is right, but it fixes sounds in OutRun
+                self.channels[6].set_key_on(false);
+                self.channels[7].set_key_on(false);
+                self.channels[8].set_key_on(false);
+            }
+        }
+        self.rhythm_mode_enabled = rhythm_mode_enabled;
+
+        log::trace!("  Rhythm mode enabled: {rhythm_mode_enabled}");
+
+        if rhythm_mode_enabled {
+            let bass_drum_on = value.bit(4);
+            let snare_drum_on = value.bit(3);
+            let tom_tom_on = value.bit(2);
+            let top_cymbal_on = value.bit(1);
+            let high_hat_on = value.bit(0);
+
+            self.channels[6].set_key_on(bass_drum_on);
+            self.channels[7].set_key_on(snare_drum_on || high_hat_on);
+            self.channels[8].set_key_on(tom_tom_on || top_cymbal_on);
+
+            self.rhythm_settings.snare_drum_on = snare_drum_on;
+            self.rhythm_settings.tom_tom_on = tom_tom_on;
+            self.rhythm_settings.top_cymbal_on = top_cymbal_on;
+            self.rhythm_settings.high_hat_on = high_hat_on;
+
+            log::trace!("  Bass drum on: {}", value.bit(4));
+            log::trace!("  Snare drum on: {}", value.bit(3));
+            log::trace!("  Tom-tom on: {}", value.bit(2));
+            log::trace!("  Top cymbal on: {}", value.bit(1));
+            log::trace!("  High hat on: {}", value.bit(0));
+        }
+    }
+
+    pub fn tick(&mut self) {
+        self.divider -= 1;
+        if self.divider == 0 {
+            self.divider = YM2413_DIVIDER;
+
+            self.am_unit.clock();
+            self.fm_unit.clock();
+            self.shift_lfsr();
+
+            let am_output = self.am_unit.output();
+            let fm_position = self.fm_unit.position;
+            for channel in &mut self.channels {
+                channel.clock(am_output, fm_position);
+            }
+        }
+    }
+
+    fn shift_lfsr(&mut self) {
+        let xor_operand = if self.lfsr.bit(0) {
+            // Flip bits 22, 8, 7, and 0
+            0x400181
+        } else {
+            0
+        };
+        self.lfsr = (self.lfsr >> 1) ^ xor_operand;
+    }
+
+    pub fn sample(&self) -> f64 {
+        let sample = if self.rhythm_mode_enabled {
+            let melodic = self.channels[..6]
+                .iter()
+                .map(|channel| f64::from(channel.sample()) / MAX_CARRIER_OUTPUT)
+                .sum::<f64>();
+            let bass_drum = f64::from(self.channels[6].sample()) / MAX_CARRIER_OUTPUT;
+            let snare_drum = self.snare_drum_sample();
+            let tom_tom = self.tom_tom_sample();
+            let top_cymbal = self.top_cymbal_sample();
+            let high_hat = self.high_hat_sample();
+            melodic + 2.0 * (bass_drum + snare_drum + tom_tom + top_cymbal + high_hat)
+        } else {
+            self.channels
+                .iter()
+                .map(|channel| f64::from(channel.sample()) / MAX_CARRIER_OUTPUT)
+                .sum::<f64>()
+        };
+
+        (sample / 9.0).clamp(-1.0, 1.0)
+    }
+
+    // Rhythm instrument formulas based on https://github.com/andete/ym2413/blob/master/results/rhythm/rhythm.md
+
+    fn snare_drum_sample(&self) -> f64 {
+        let operator = &self.channels[7].carrier;
+
+        if !self.rhythm_settings.snare_drum_on || operator.envelope.attenuation >= ENVELOPE_END {
+            return 0.0;
+        }
+
+        let phase = operator.phase.counter.bit(18);
+        let (sine_attenuation, sign) = match (self.lfsr.bit(0), phase) {
+            (false, false) | (true, true) => log_sine_lookup(0),
+            (false, true) => (0, Sign::Negative),
+            (true, false) => (0, Sign::Positive),
+        };
+
+        let total_attenuation = rhythm_attenuation(
+            operator.envelope.attenuation,
+            self.rhythm_settings.snare_drum_volume,
+        );
+        let amplitude = compute_amplitude(sine_attenuation + 16 * total_attenuation, sign) >> 4;
+        f64::from(amplitude) / MAX_CARRIER_OUTPUT
+    }
+
+    fn tom_tom_sample(&self) -> f64 {
+        if self.rhythm_settings.tom_tom_on {
+            f64::from(self.channels[8].modulator.current_output >> 4) / MAX_CARRIER_OUTPUT
+        } else {
+            0.0
+        }
+    }
+
+    fn top_cymbal_sample(&self) -> f64 {
+        let operator = &self.channels[8].carrier;
+
+        if !self.rhythm_settings.top_cymbal_on || operator.envelope.attenuation >= ENVELOPE_END {
+            return 0.0;
+        }
+
+        let sign = if self.top_cymbal_high_hat_phase() { Sign::Positive } else { Sign::Negative };
+
+        let total_attenuation = rhythm_attenuation(
+            operator.envelope.attenuation,
+            self.rhythm_settings.top_cymbal_volume,
+        );
+        // Sine attenuation is always 0
+        let amplitude = compute_amplitude(16 * total_attenuation, sign) >> 4;
+        f64::from(amplitude) / MAX_CARRIER_OUTPUT
+    }
+
+    fn high_hat_sample(&self) -> f64 {
+        let operator = &self.channels[7].modulator;
+
+        if !self.rhythm_settings.high_hat_on || operator.envelope.attenuation >= ENVELOPE_END {
+            return 0.0;
+        }
+
+        let phase = match (self.lfsr.bit(0), self.top_cymbal_high_hat_phase()) {
+            (false, false) => 0x2D0,
+            (false, true) => 0x34,
+            (true, false) => 0x234,
+            (true, true) => 0xD0,
+        };
+        let (sine_attenuation, sign) = log_sine_lookup(phase);
+
+        let total_attenuation =
+            rhythm_attenuation(operator.envelope.attenuation, self.rhythm_settings.high_hat_volume);
+        let amplitude = compute_amplitude(sine_attenuation + 16 * total_attenuation, sign) >> 4;
+        f64::from(amplitude) / MAX_CARRIER_OUTPUT
+    }
+
+    fn top_cymbal_high_hat_phase(&self) -> bool {
+        let c8_phase = self.channels[8].carrier.phase.counter >> 9;
+        let m7_phase = self.channels[7].modulator.phase.counter >> 9;
+
+        let c8_3 = c8_phase.bit(3);
+        let c8_5 = c8_phase.bit(5);
+        let m7_2 = m7_phase.bit(2);
+        let m7_3 = m7_phase.bit(3);
+        let m7_7 = m7_phase.bit(7);
+
+        (c8_5 ^ c8_3) && (m7_7 ^ m7_2) && (c8_5 ^ m7_3)
+    }
+}
+
+fn rhythm_attenuation(envelope_attenuation: u8, volume: u8) -> u16 {
+    cmp::min(u16::from(MAX_ATTENUATION), u16::from(envelope_attenuation) + u16::from(volume << 3))
+}


### PR DESCRIPTION
The Mark III (JP) had an optional FM sound unit expansion, and the JP Sega Master System had the FM sound unit built in. It was never released outside of Japan but some US-released games will use it if they detect it.

The sound unit core is a YM2413, also known as the OPLL. Unlike more advanced FM synthesizers, it doesn't have fully configurable FM instruments. Instead it has 15 preset instruments in ROM with only 1 fully configurable instrument that is shared across all channels.

The chip has 2 modes: "melodic mode" where all 9 channels can be configured, and "rhythm mode" where 6 channels can be configured and the other 3 are used for 5 preset percussion instruments (bass drum, snare drum, tom-tom, top cymbal, high hat).