### PR TITLE
Add support for the SVP chip

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ Cross-platform multi-console Sega emulator that supports the Sega Genesis / Mega
 
 TODOs:
 * Emulate the Genesis VDP FIFO, in particular the fact that the CPU stalls if it writes to VRAM too rapidly during active display. A few games depend on this to function correctly (e.g. _The Chaos Engine_, _Double Clutch_, _Sol-Deace_), and a few other games have graphical glitches if it's not emulated (e.g. the EA logo flickering for a single frame, parts of the _Batman Returns_ intro running too fast)
-* Support the Sega Virtua Processor (SVP) chip; used only by _Virtua Racing_
 * Support 24C64 EEPROM chips (used only in _Frank Thomas Big Hurt Baseball_ and _College Slam_)
 * Support the Sega Master System's additional graphics modes (Modes 0-3); only one officially released game used any of them, _F-16 Fighter_ (which uses Mode 2)
 * Support multiple Sega CD BIOS versions in GUI and automatically use the correct one based on disc region
@@ -111,3 +110,4 @@ RUSTFLAGS="-Ctarget-cpu=native" cargo build --profile release-lto
 * Mega CD official documentation: https://segaretro.org/Mega-CD_official_documentation
 * ECMA-130 standard: https://www.ecma-international.org/publications-and-standards/standards/ecma-130/
 * Thread discussing details of Mega CD emulation: https://gendev.spritesmind.net/forum/viewtopic.php?t=3020
+* SVP documentation by notaz, as well as earlier documentation work by Tasco Deluxe: https://notaz.gp2x.de/docs/svpdoc.txt

--- a/genesis-core/src/api.rs
+++ b/genesis-core/src/api.rs
@@ -320,6 +320,8 @@ impl TickableEmulator for GenesisEmulator {
             self.z80.tick(&mut bus);
         }
 
+        self.memory.medium_mut().tick(m68k_cycles);
+
         self.input.tick(m68k_cycles);
 
         // The PSG uses the same master clock divider as the Z80, but it needs to be ticked in a

--- a/genesis-core/src/lib.rs
+++ b/genesis-core/src/lib.rs
@@ -2,6 +2,7 @@ mod api;
 pub mod audio;
 pub mod input;
 pub mod memory;
+mod svp;
 pub mod vdp;
 pub mod ym2612;
 

--- a/genesis-core/src/svp.rs
+++ b/genesis-core/src/svp.rs
@@ -1,0 +1,469 @@
+mod ssp1601;
+
+use bincode::{Decode, Encode};
+use jgenesis_traits::num::GetBit;
+use std::array;
+
+const SVP_ENTRY_POINT: u16 = 0x400;
+
+const DRAM_LEN: usize = 128 * 1024;
+const IRAM_LEN_WORDS: usize = 1024;
+const INTERNAL_RAM_LEN_WORDS: usize = 256;
+
+const STACK_LEN: usize = 6;
+
+// External memory addresses are 21-bit
+const EXTERNAL_MEMORY_MASK: u32 = (1 << 21) - 1;
+
+type Dram = [u8; DRAM_LEN];
+type Iram = [u16; IRAM_LEN_WORDS];
+type InternalRam = [u16; INTERNAL_RAM_LEN_WORDS];
+
+#[derive(Debug, Clone, Copy, Default, Encode, Decode)]
+struct StatusRegister {
+    loop_size: u8,
+    st5: bool,
+    st6: bool,
+    zero: bool,
+    negative: bool,
+}
+
+impl StatusRegister {
+    fn loop_modulo(self) -> u8 {
+        if self.loop_size != 0 { 1 << self.loop_size } else { 0 }
+    }
+
+    fn st_bits_set(self) -> bool {
+        self.st5 || self.st6
+    }
+
+    fn write(&mut self, value: u16) {
+        self.loop_size = (value & 0x07) as u8;
+        self.st5 = value.bit(5);
+        self.st6 = value.bit(6);
+        self.zero = value.bit(13);
+        self.negative = value.bit(15);
+    }
+}
+
+impl From<StatusRegister> for u16 {
+    fn from(value: StatusRegister) -> Self {
+        (u16::from(value.negative) << 15)
+            | (u16::from(value.zero) << 13)
+            | (u16::from(value.st6) << 6)
+            | (u16::from(value.st5) << 5)
+            | u16::from(value.loop_size)
+    }
+}
+
+#[derive(Debug, Clone, Default, Encode, Decode)]
+struct StackRegister {
+    stack: [u16; STACK_LEN],
+    pointer: u8,
+}
+
+impl StackRegister {
+    fn push(&mut self, value: u16) {
+        self.stack[self.pointer as usize] = value;
+        self.pointer += 1;
+    }
+
+    fn pop(&mut self) -> u16 {
+        self.pointer -= 1;
+        self.stack[self.pointer as usize]
+    }
+}
+
+#[derive(Debug, Clone, Default, Encode, Decode)]
+struct ProgrammableMemoryRegister {
+    address: u32,
+    auto_increment: u32,
+    auto_increment_negative: bool,
+    auto_increment_bits: u16,
+    special_increment_mode: bool,
+    overwrite_mode: bool,
+}
+
+impl ProgrammableMemoryRegister {
+    fn initialize(&mut self, address: u16, mode: u16) {
+        // Bits 4-0 of mode are bits 20-16 of the 21-bit address
+        self.address = u32::from(address) | (u32::from(mode & 0x001F) << 16);
+
+        self.overwrite_mode = mode.bit(10);
+
+        // Auto increment bits of 0 indicate 0, 7 indicate 128, and other values indicate 2^(N-1)
+        let auto_increment_bits = (mode >> 11) & 0x07;
+        self.auto_increment_bits = auto_increment_bits;
+        self.auto_increment = match auto_increment_bits {
+            0 => 0,
+            7 => 128,
+            _ => 1 << (auto_increment_bits - 1),
+        };
+
+        self.special_increment_mode = mode.bit(14);
+        self.auto_increment_negative = mode.bit(15);
+    }
+
+    fn get_and_increment_address(&mut self) -> u32 {
+        let address = self.address;
+
+        if self.special_increment_mode {
+            // "Special" increment mode increments the address by 1 if it is even and 31 if it is odd
+            if !address.bit(0) {
+                self.address = (self.address + 1) & EXTERNAL_MEMORY_MASK;
+            } else {
+                self.address = (self.address + 31) & EXTERNAL_MEMORY_MASK;
+            }
+        } else if self.auto_increment != 0 {
+            if self.auto_increment_negative {
+                self.address =
+                    self.address.wrapping_sub(self.auto_increment) & EXTERNAL_MEMORY_MASK;
+            } else {
+                self.address =
+                    self.address.wrapping_add(self.auto_increment) & EXTERNAL_MEMORY_MASK;
+            }
+        }
+
+        address
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Encode, Decode)]
+enum PmcWaitingFor {
+    #[default]
+    Address,
+    Mode,
+}
+
+impl PmcWaitingFor {
+    fn toggle(self) -> Self {
+        match self {
+            Self::Address => Self::Mode,
+            Self::Mode => Self::Address,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, Encode, Decode)]
+struct ProgrammableMemoryControlRegister {
+    waiting_for: PmcWaitingFor,
+    address: u16,
+    mode: u16,
+}
+
+impl ProgrammableMemoryControlRegister {
+    fn read(&mut self) -> u16 {
+        let value = match self.waiting_for {
+            PmcWaitingFor::Address => self.address,
+            PmcWaitingFor::Mode => {
+                // If waiting for mode, return address but rotated by 4; direction doesn't matter
+                // since SVP always does this with both bytes equal
+                (self.address << 4) | (self.address >> 12)
+            }
+        };
+
+        self.waiting_for = self.waiting_for.toggle();
+
+        value
+    }
+
+    fn write(&mut self, value: u16) {
+        match self.waiting_for {
+            PmcWaitingFor::Address => {
+                self.address = value;
+            }
+            PmcWaitingFor::Mode => {
+                self.mode = value;
+            }
+        }
+
+        self.waiting_for = self.waiting_for.toggle();
+    }
+
+    fn update_from(&mut self, pm_register: &ProgrammableMemoryRegister) {
+        self.address = pm_register.address as u16;
+        self.mode = (u16::from(pm_register.auto_increment_negative) << 15)
+            | (u16::from(pm_register.special_increment_mode) << 14)
+            | (pm_register.auto_increment_bits << 11)
+            | (u16::from(pm_register.overwrite_mode) << 10)
+            | (pm_register.address >> 16) as u16;
+
+        log::trace!("Set PMC address to {:04X} and mode to {:04X}", self.address, self.mode);
+    }
+}
+
+#[derive(Debug, Clone, Default, Encode, Decode)]
+struct ExternalStatusRegister {
+    value: u16,
+    m68k_written: bool,
+    ssp_written: bool,
+}
+
+impl ExternalStatusRegister {
+    fn m68k_write(&mut self, value: u16) {
+        self.value = value;
+        self.m68k_written = true;
+    }
+
+    fn ssp_write(&mut self, value: u16) {
+        self.value = value;
+        self.ssp_written = true;
+    }
+
+    fn status(&self) -> u16 {
+        (u16::from(self.m68k_written) << 1) | u16::from(self.ssp_written)
+    }
+
+    fn m68k_read_status(&mut self) -> u16 {
+        let status = self.status();
+        self.ssp_written = false;
+        status
+    }
+
+    fn ssp_read_status(&mut self) -> u16 {
+        let status = self.status();
+        self.m68k_written = false;
+        status
+    }
+}
+
+#[derive(Debug, Clone, Encode, Decode)]
+struct Registers {
+    // General registers (0-7)
+    x: u16,
+    y: u16,
+    accumulator: u32,
+    status: StatusRegister,
+    stack: StackRegister,
+    pc: u16,
+    // External registers (8-15)
+    pm_read: [ProgrammableMemoryRegister; 5],
+    pm_write: [ProgrammableMemoryRegister; 5],
+    pmc: ProgrammableMemoryControlRegister,
+    xst: ExternalStatusRegister,
+    // Pointer registers (0-2 and 4-6, 3 and 7 are not stored)
+    ram0_pointers: [u8; 3],
+    ram1_pointers: [u8; 3],
+}
+
+impl Registers {
+    fn new() -> Self {
+        Self {
+            x: 0,
+            y: 0,
+            accumulator: 0,
+            status: StatusRegister::default(),
+            stack: StackRegister::default(),
+            pc: SVP_ENTRY_POINT,
+            pm_read: array::from_fn(|_| ProgrammableMemoryRegister::default()),
+            pm_write: array::from_fn(|_| ProgrammableMemoryRegister::default()),
+            pmc: ProgrammableMemoryControlRegister::default(),
+            xst: ExternalStatusRegister::default(),
+            ram0_pointers: [0; 3],
+            ram1_pointers: [0; 3],
+        }
+    }
+
+    fn product(&self) -> u32 {
+        // P register always contains 2 * X * Y, where X and Y are sign extended from 16 bits to 32 bits
+        2_u32.wrapping_mul(self.x as i16 as u32).wrapping_mul(self.y as i16 as u32)
+    }
+}
+
+#[derive(Debug, Clone, Encode, Decode)]
+pub struct Svp {
+    registers: Registers,
+    dram: Box<Dram>,
+    dram_dirty: bool,
+    iram: Box<Iram>,
+    ram0: Box<InternalRam>,
+    ram1: Box<InternalRam>,
+    halted: bool,
+}
+
+impl Svp {
+    pub fn new() -> Self {
+        Self {
+            registers: Registers::new(),
+            dram_dirty: false,
+            dram: vec![0; DRAM_LEN].into_boxed_slice().try_into().unwrap(),
+            iram: vec![0; IRAM_LEN_WORDS].into_boxed_slice().try_into().unwrap(),
+            ram0: vec![0; INTERNAL_RAM_LEN_WORDS].into_boxed_slice().try_into().unwrap(),
+            ram1: vec![0; INTERNAL_RAM_LEN_WORDS].into_boxed_slice().try_into().unwrap(),
+            halted: false,
+        }
+    }
+
+    pub fn tick(&mut self, rom: &[u8], m68k_cycles: u32) {
+        if self.halted {
+            return;
+        }
+
+        // Somewhat arbitrarily execute 3 instructions for every 68k cycle; this is close enough to
+        // the chip's actual speed of somewhere in the 20-25 MHz range, and Virtua Racing's code is
+        // not timing-sensitive
+        for _ in 0..3 * m68k_cycles {
+            // Hacky idle loop detection: if the SSP1601 is waiting for the 68000 to give it a
+            // command, don't bother executing anything until the 68000 writes to $FE06 or $FE08 in
+            // DRAM
+            if self.registers.pc == 0x0425 || self.registers.pc == 0x2789 {
+                if !self.dram_dirty {
+                    return;
+                }
+                self.dram_dirty = false;
+            }
+
+            // At startup, the SVP spins until the 68000 writes to the XST; don't execute until that
+            // happens
+            if self.registers.pc == 0x0400 && !self.registers.xst.m68k_written {
+                return;
+            }
+
+            ssp1601::execute_instruction(self, rom);
+        }
+    }
+
+    pub fn m68k_read(&mut self, address: u32, rom: &[u8]) -> u16 {
+        match address {
+            0x000000..=0x1FFFFF => {
+                // ROM
+                let msb = rom[address as usize];
+                let lsb = rom[(address + 1) as usize];
+                u16::from_be_bytes([msb, lsb])
+            }
+            0x300000..=0x37FFFF => {
+                // DRAM
+                let address = address & 0x1FFFF;
+                let msb = self.dram[address as usize];
+                let lsb = self.dram[(address + 1) as usize];
+                u16::from_be_bytes([msb, lsb])
+            }
+            0xA15000 | 0xA15002 => {
+                // XST register
+                self.registers.xst.value
+            }
+            0xA15004 => {
+                // XST status
+                self.registers.xst.m68k_read_status()
+            }
+            _ => {
+                // Invalid or unused
+                0xFFFF
+            }
+        }
+    }
+
+    pub fn m68k_write_byte(&mut self, address: u32, value: u8) {
+        match address {
+            0x300000..=0x37FFFF => {
+                // DRAM
+                self.dram[(address & 0x1FFFF) as usize] = value;
+
+                if (0xFE06..0xFE0A).contains(&address) {
+                    self.dram_dirty = true;
+                }
+            }
+            _ => {
+                // Treat other writes as word-size
+                if address.bit(0) {
+                    self.m68k_write_word(address & !1, value.into());
+                } else {
+                    self.m68k_write_word(address, u16::from(value) << 8);
+                }
+            }
+        }
+    }
+
+    pub fn m68k_write_word(&mut self, address: u32, value: u16) {
+        match address {
+            0x300000..=0x37FFFF => {
+                // DRAM
+                let address = address & 0x1FFFF;
+                let [msb, lsb] = value.to_be_bytes();
+                self.dram[address as usize] = msb;
+                self.dram[(address + 1) as usize] = lsb;
+
+                if address == 0xFE06 || address == 0xFE08 {
+                    self.dram_dirty = true;
+                }
+            }
+            0xA15000 | 0xA15002 => {
+                // XST register
+                self.registers.xst.m68k_write(value);
+            }
+            0xA15006 => {
+                // SVP halt register
+                self.halted = value == 0x000A;
+            }
+            _ => {
+                // Invalid or unused
+            }
+        }
+    }
+
+    fn read_program_memory(&self, address: u16, rom: &[u8]) -> u16 {
+        match address {
+            0x0000..=0x03FF => {
+                // IRAM
+                self.iram[address as usize]
+            }
+            0x0400..=0xFFFF => {
+                // ROM; program memory address maps to the same address in ROM
+                let byte_addr = u32::from(address) << 1;
+                let msb = rom[byte_addr as usize];
+                let lsb = rom[(byte_addr + 1) as usize];
+                u16::from_be_bytes([msb, lsb])
+            }
+        }
+    }
+
+    fn read_external_memory(&mut self, address: u32, rom: &[u8]) -> u16 {
+        log::trace!("External memory read: {address:06X}");
+
+        match address {
+            0x000000..=0x0FFFFF => {
+                // ROM
+                let byte_addr = address << 1;
+                let msb = rom[byte_addr as usize];
+                let lsb = rom[(byte_addr + 1) as usize];
+                u16::from_be_bytes([msb, lsb])
+            }
+            0x180000..=0x18FFFF => {
+                // DRAM
+                let byte_addr = (address & 0xFFFF) << 1;
+                let msb = self.dram[byte_addr as usize];
+                let lsb = self.dram[(byte_addr + 1) as usize];
+                u16::from_be_bytes([msb, lsb])
+            }
+            0x1C8000..=0x1C83FF => {
+                // IRAM
+                self.iram[(address & 0x3FF) as usize]
+            }
+            _ => {
+                // Invalid or unused
+                0xFFFF
+            }
+        }
+    }
+
+    fn write_external_memory(&mut self, address: u32, value: u16) {
+        log::trace!("External memory write: {address:06X} {value:04X}");
+
+        match address {
+            0x180000..=0x18FFFF => {
+                // DRAM
+                let byte_addr = (address & 0xFFFF) << 1;
+                let [msb, lsb] = value.to_be_bytes();
+                self.dram[byte_addr as usize] = msb;
+                self.dram[(byte_addr + 1) as usize] = lsb;
+            }
+            0x1C8000..=0x1C83FF => {
+                // IRAM
+                self.iram[(address & 0x3FF) as usize] = value;
+            }
+            _ => {
+                // Invalid or unused
+            }
+        }
+    }
+}

--- a/genesis-core/src/svp/ssp1601.rs
+++ b/genesis-core/src/svp/ssp1601.rs
@@ -1,0 +1,912 @@
+use crate::svp::{PmcWaitingFor, StatusRegister, Svp};
+use jgenesis_traits::num::GetBit;
+use std::fmt::{Display, Formatter};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AluOp {
+    Add,
+    Subtract,
+    Compare,
+    And,
+    Or,
+    ExclusiveOr,
+}
+
+impl AluOp {
+    fn from_opcode(opcode: u16) -> Option<Self> {
+        match opcode & 0xE000 {
+            0x2000 => Some(Self::Subtract),
+            0x6000 => Some(Self::Compare),
+            0x8000 => Some(Self::Add),
+            0xA000 => Some(Self::And),
+            0xC000 => Some(Self::Or),
+            0xE000 => Some(Self::ExclusiveOr),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MultiplyOp {
+    Zero,
+    Add,
+    Subtract,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Condition {
+    True,
+    Zero(bool),
+    Negative(bool),
+}
+
+impl Condition {
+    fn from_opcode(opcode: u16) -> Self {
+        match opcode & 0x00F0 {
+            0x0000 => Self::True,
+            0x0050 => Self::Zero(opcode.bit(8)),
+            0x0070 => Self::Negative(opcode.bit(8)),
+            _ => panic!("Invalid SVP opcode (invalid condition): {opcode:04X}"),
+        }
+    }
+
+    fn check(self, status: StatusRegister) -> bool {
+        match self {
+            Self::True => true,
+            Self::Zero(value) => status.zero == value,
+            Self::Negative(value) => status.negative == value,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RamBank {
+    Zero,
+    One,
+}
+
+impl RamBank {
+    fn from_opcode(opcode: u16) -> Self {
+        if opcode.bit(8) { Self::One } else { Self::Zero }
+    }
+}
+
+impl Display for RamBank {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Zero => write!(f, "RAM0"),
+            Self::One => write!(f, "RAM1"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AddressingMode {
+    GeneralRegister(u16),
+    PointerRegister(RamBank, u16),
+    Indirect { bank: RamBank, pointer: u16, modifier: u16 },
+    DoubleIndirect { bank: RamBank, pointer: u16, modifier: u16 },
+    Direct { bank: RamBank, address: u8 },
+    Immediate,
+    ShortImmediate(u8),
+    AccumulatorIndirect,
+}
+
+impl AddressingMode {
+    const ACCUMULATOR_REGISTER: Self = Self::GeneralRegister(3);
+}
+
+impl Display for AddressingMode {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::GeneralRegister(0) => write!(f, "NULL"),
+            Self::GeneralRegister(1) => write!(f, "X"),
+            Self::GeneralRegister(2) => write!(f, "Y"),
+            Self::GeneralRegister(3) => write!(f, "AH"),
+            Self::GeneralRegister(4) => write!(f, "ST"),
+            Self::GeneralRegister(5) => write!(f, "STACK"),
+            Self::GeneralRegister(6) => write!(f, "PC"),
+            Self::GeneralRegister(7) => write!(f, "P"),
+            Self::GeneralRegister(8) => write!(f, "PM0/XSTStatus"),
+            Self::GeneralRegister(9) => write!(f, "PM1"),
+            Self::GeneralRegister(10) => write!(f, "PM2"),
+            Self::GeneralRegister(11) => write!(f, "PM3/XST"),
+            Self::GeneralRegister(12) => write!(f, "PM4"),
+            Self::GeneralRegister(14) => write!(f, "PMC"),
+            Self::GeneralRegister(15) => write!(f, "AL"),
+            Self::GeneralRegister(_) => write!(f, "(invalid register)"),
+            Self::PointerRegister(bank, pointer) => write!(f, "RIJ[{bank}, {pointer}]"),
+            Self::Indirect { bank, pointer, modifier } => {
+                write!(f, "(RIJ)[{bank}, {pointer}]/mod={modifier}")
+            }
+            Self::DoubleIndirect { bank, pointer, modifier } => {
+                write!(f, "((RIJ))[{bank}, {pointer}]/mod={modifier}")
+            }
+            Self::Direct { bank, address } => write!(f, "{bank}[{address:02X}]"),
+            Self::Immediate => write!(f, "#<imm>"),
+            Self::ShortImmediate(value) => write!(f, "#<{value:02X}>"),
+            Self::AccumulatorIndirect => write!(f, "(AH)"),
+        }
+    }
+}
+
+pub fn execute_instruction(svp: &mut Svp, rom: &[u8]) {
+    let opcode = fetch_operand(svp, rom);
+
+    log::trace!("PC={:04X}, opcode={opcode:04X}", svp.registers.pc.wrapping_sub(1));
+
+    // The first 8 bits are enough to distinguish between all opcodes
+    match opcode & 0xFF00 {
+        0x0000 => {
+            // ld d, s
+            ld_d_s(svp, rom, opcode);
+        }
+        0x0200 | 0x0300 => {
+            // ld d, (ri)
+            ld_d_ri_indirect(svp, rom, opcode);
+        }
+        0x0400 | 0x0500 => {
+            // ld (ri), s
+            ld_ri_s_indirect(svp, rom, opcode);
+        }
+        0x0600 | 0x0700 => {
+            // ld A, addr
+            ld_a_addr(svp, rom, opcode);
+        }
+        0x0800 => {
+            // ldi d, imm
+            ldi_d_imm(svp, rom, opcode);
+        }
+        0x0A00 | 0x0B00 => {
+            // ld d, ((ri))
+            ld_d_ri_double_indirect(svp, rom, opcode);
+        }
+        0x0C00 | 0x0D00 => {
+            // ldi (ri), imm
+            ldi_ri_imm(svp, rom, opcode);
+        }
+        0x0E00 | 0x0F00 => {
+            // ld addr, A
+            ld_addr_a(svp, rom, opcode);
+        }
+        0x1200 | 0x1300 => {
+            // ld d, ri
+            ld_d_ri(svp, rom, opcode);
+        }
+        0x1400 | 0x1500 => {
+            // ld ri, s
+            ld_ri_s(svp, rom, opcode);
+        }
+        0x1800..=0x1F00 => {
+            // ldi ri, simm
+            ldi_ri_simm(svp, rom, opcode);
+        }
+        0x3700 => {
+            // mpys (rj), (ri)
+            execute_multiply(svp, opcode, MultiplyOp::Subtract);
+        }
+        0x4800 | 0x4900 => {
+            // call cond, addr
+            execute_call(svp, rom, opcode);
+        }
+        0x4A00 => {
+            // ld d, (a)
+            ld_d_a_indirect(svp, rom, opcode);
+        }
+        0x4C00 | 0x4D00 => {
+            // bra cond, addr
+            execute_bra(svp, rom, opcode);
+        }
+        0x9000 | 0x9100 => {
+            // Accumulator-only ALU ops (right shift, left shift, negate, absolute value)
+            execute_accumulator_modify(svp, opcode);
+        }
+        0x9700 => {
+            // mpya (rj), (ri)
+            execute_multiply(svp, opcode, MultiplyOp::Add);
+        }
+        0xB700 => {
+            // mld (rj), (ri)
+            execute_multiply(svp, opcode, MultiplyOp::Zero);
+        }
+        0xFF00 => {
+            // Treat as a no-op; do nothing
+        }
+        _ => {
+            // ALU ops; highest 3 bits determine op, next 5 bits determine addressing mode
+            execute_alu(svp, rom, opcode);
+        }
+    }
+}
+
+fn fetch_operand(svp: &mut Svp, rom: &[u8]) -> u16 {
+    let operand = svp.read_program_memory(svp.registers.pc, rom);
+    svp.registers.pc = svp.registers.pc.wrapping_add(1);
+    operand
+}
+
+fn execute_load(svp: &mut Svp, rom: &[u8], source: AddressingMode, dest: AddressingMode) {
+    log::trace!("  LD source={source}, dest={dest}");
+
+    match (source, dest) {
+        (AddressingMode::GeneralRegister(7), AddressingMode::GeneralRegister(3)) => {
+            // P to A; copy all 32 bits
+            svp.registers.accumulator = svp.registers.product();
+            log::trace!("  A = {:08X}", svp.registers.accumulator);
+        }
+        (
+            AddressingMode::GeneralRegister(0),
+            AddressingMode::GeneralRegister(register @ 8..=15),
+        ) => {
+            // Blind write; program PM register (if applicable) and reset PMC state
+            log::trace!("Blind write to register {register}");
+            if register <= 12 {
+                let pm_idx = (register - 8) as usize;
+                svp.registers.pm_write[pm_idx]
+                    .initialize(svp.registers.pmc.address, svp.registers.pmc.mode);
+                log::trace!(
+                    "Initialized PM{pm_idx} for writes: {:X?}",
+                    svp.registers.pm_write[pm_idx]
+                );
+            }
+            if register != 14 {
+                svp.registers.pmc.waiting_for = PmcWaitingFor::Address;
+            } else {
+                svp.registers.pmc.waiting_for = svp.registers.pmc.waiting_for.toggle();
+            }
+        }
+        (
+            AddressingMode::GeneralRegister(register @ 8..=15),
+            AddressingMode::GeneralRegister(0),
+        ) => {
+            // Blind read; program PM register (if applicable) and reset PMC state
+            log::trace!("Blind read to register {register}");
+            if register <= 12 {
+                let pm_idx = (register - 8) as usize;
+                svp.registers.pm_read[pm_idx]
+                    .initialize(svp.registers.pmc.address, svp.registers.pmc.mode);
+                log::trace!(
+                    "Initialized PM{pm_idx} for reads: {:X?}",
+                    svp.registers.pm_read[pm_idx]
+                );
+            }
+            if register != 14 {
+                svp.registers.pmc.waiting_for = PmcWaitingFor::Address;
+            } else {
+                svp.registers.pmc.waiting_for = svp.registers.pmc.waiting_for.toggle();
+            }
+        }
+        _ => {
+            // Normal 16-bit load
+            let value = read_addressing_mode(svp, rom, source);
+            log::trace!("  Writing value {value:04X}");
+            write_addressing_mode(svp, dest, value);
+        }
+    }
+}
+
+fn execute_alu(svp: &mut Svp, rom: &[u8], opcode: u16) {
+    let Some(op) = AluOp::from_opcode(opcode) else {
+        panic!("Invalid SSP1601 opcode: {opcode:04X}");
+    };
+
+    let source = parse_alu_addressing_mode(opcode);
+
+    log::trace!("  ALU op={op:?}, source={source}");
+
+    let operand = match source {
+        AddressingMode::GeneralRegister(3) => svp.registers.accumulator,
+        AddressingMode::GeneralRegister(7) => svp.registers.product(),
+        _ => u32::from(read_addressing_mode(svp, rom, source)) << 16,
+    };
+
+    let accumulator = svp.registers.accumulator;
+    let result = match op {
+        AluOp::Add => accumulator.wrapping_add(operand),
+        AluOp::Subtract | AluOp::Compare => accumulator.wrapping_sub(operand),
+        AluOp::And => accumulator & operand,
+        AluOp::Or => accumulator | operand,
+        AluOp::ExclusiveOr => accumulator ^ operand,
+    };
+
+    update_flags(svp, result);
+
+    log::trace!("  Op result = {result:08X}");
+
+    if op != AluOp::Compare {
+        svp.registers.accumulator = result;
+    }
+}
+
+fn update_flags(svp: &mut Svp, accumulator: u32) {
+    svp.registers.status.zero = accumulator == 0;
+    svp.registers.status.negative = accumulator.bit(31);
+}
+
+fn execute_accumulator_modify(svp: &mut Svp, opcode: u16) {
+    let condition = Condition::from_opcode(opcode);
+    if !condition.check(svp.registers.status) {
+        log::trace!("  MODIFY cond={condition:?}, condition false");
+        return;
+    }
+
+    // Lowest 3 bits determine operation
+    match opcode & 0x0007 {
+        0x0002 => {
+            // Arithmetic right shift
+            log::trace!("  ASR cond={condition:?}");
+            svp.registers.accumulator = ((svp.registers.accumulator as i32) >> 1) as u32;
+        }
+        0x0003 => {
+            // Left shift
+            log::trace!("  SL cond={condition:?}");
+            svp.registers.accumulator <<= 1;
+        }
+        0x0006 => {
+            // Negate
+            log::trace!("  NEG cond={condition:?}");
+            svp.registers.accumulator = (!svp.registers.accumulator).wrapping_add(1);
+        }
+        0x0007 => {
+            // Absolute value
+            log::trace!("  ABS cond={condition:?}");
+            if svp.registers.accumulator.bit(31) {
+                svp.registers.accumulator = (!svp.registers.accumulator).wrapping_add(1);
+            }
+        }
+        _ => panic!("Invalid SVP opcode: {opcode:04X}"),
+    }
+
+    update_flags(svp, svp.registers.accumulator);
+}
+
+fn execute_call(svp: &mut Svp, rom: &[u8], opcode: u16) {
+    let address = fetch_operand(svp, rom);
+    let condition = Condition::from_opcode(opcode);
+
+    log::trace!("  CALL cond={condition:?}, address={address:04X}");
+
+    if condition.check(svp.registers.status) {
+        svp.registers.stack.push(svp.registers.pc);
+        svp.registers.pc = address;
+    }
+}
+
+fn execute_bra(svp: &mut Svp, rom: &[u8], opcode: u16) {
+    let address = fetch_operand(svp, rom);
+    let condition = Condition::from_opcode(opcode);
+
+    log::trace!("  BRA cond={condition:?}, address={address:04X}");
+
+    if condition.check(svp.registers.status) {
+        svp.registers.pc = address;
+    }
+}
+
+fn execute_multiply(svp: &mut Svp, opcode: u16, op: MultiplyOp) {
+    match op {
+        MultiplyOp::Zero => {
+            svp.registers.accumulator = 0;
+        }
+        MultiplyOp::Add => {
+            svp.registers.accumulator =
+                svp.registers.accumulator.wrapping_add(svp.registers.product());
+        }
+        MultiplyOp::Subtract => {
+            svp.registers.accumulator =
+                svp.registers.accumulator.wrapping_sub(svp.registers.product());
+        }
+    }
+
+    update_flags(svp, svp.registers.accumulator);
+
+    let x_pointer = opcode & 0x03;
+    let x_modifier = (opcode >> 2) & 0x03;
+    let ram0_addr = read_pointer(svp, RamBank::Zero, x_pointer, x_modifier);
+    svp.registers.x = svp.ram0[ram0_addr as usize];
+
+    let y_pointer = (opcode >> 4) & 0x03;
+    let y_modifier = (opcode >> 6) & 0x03;
+    let ram1_addr = read_pointer(svp, RamBank::One, y_pointer, y_modifier);
+    svp.registers.y = svp.ram1[ram1_addr as usize];
+
+    log::trace!(
+        "  MUL op={op:?}, X=RAM0[p{x_pointer}]/mod={x_modifier}, Y=RAM1[p{y_pointer}]/mod={y_modifier}"
+    );
+    log::trace!("  A={:08X}, P={:08X}", svp.registers.accumulator, svp.registers.product());
+}
+
+fn ld_d_s(svp: &mut Svp, rom: &[u8], opcode: u16) {
+    let source = AddressingMode::GeneralRegister(opcode & 0xF);
+    let dest = AddressingMode::GeneralRegister((opcode >> 4) & 0xF);
+    execute_load(svp, rom, source, dest);
+}
+
+fn ld_d_ri(svp: &mut Svp, rom: &[u8], opcode: u16) {
+    let bank = RamBank::from_opcode(opcode);
+    let pointer = opcode & 0x03;
+    let source = AddressingMode::PointerRegister(bank, pointer);
+
+    let dest = AddressingMode::GeneralRegister((opcode >> 4) & 0xF);
+
+    execute_load(svp, rom, source, dest);
+}
+
+fn ld_ri_s(svp: &mut Svp, rom: &[u8], opcode: u16) {
+    let bank = RamBank::from_opcode(opcode);
+    let pointer = opcode & 0x03;
+    let dest = AddressingMode::PointerRegister(bank, pointer);
+
+    let source = AddressingMode::GeneralRegister((opcode >> 4) & 0xF);
+
+    execute_load(svp, rom, source, dest);
+}
+
+fn ld_d_ri_indirect(svp: &mut Svp, rom: &[u8], opcode: u16) {
+    let bank = RamBank::from_opcode(opcode);
+    let pointer = opcode & 0x03;
+    let modifier = (opcode >> 2) & 0x03;
+    let source = AddressingMode::Indirect { bank, pointer, modifier };
+
+    let dest = AddressingMode::GeneralRegister((opcode >> 4) & 0xF);
+
+    execute_load(svp, rom, source, dest);
+}
+
+fn ld_ri_s_indirect(svp: &mut Svp, rom: &[u8], opcode: u16) {
+    let bank = RamBank::from_opcode(opcode);
+    let pointer = opcode & 0x03;
+    let modifier = (opcode >> 2) & 0x03;
+    let dest = AddressingMode::Indirect { bank, pointer, modifier };
+
+    let source = AddressingMode::GeneralRegister((opcode >> 4) & 0xF);
+
+    execute_load(svp, rom, source, dest);
+}
+
+fn ld_d_ri_double_indirect(svp: &mut Svp, rom: &[u8], opcode: u16) {
+    let bank = RamBank::from_opcode(opcode);
+    let pointer = opcode & 0x03;
+    let modifier = (opcode >> 2) & 0x03;
+    let source = AddressingMode::DoubleIndirect { bank, pointer, modifier };
+
+    let dest = AddressingMode::GeneralRegister((opcode >> 4) & 0xF);
+
+    execute_load(svp, rom, source, dest);
+}
+
+fn ld_a_addr(svp: &mut Svp, rom: &[u8], opcode: u16) {
+    let bank = RamBank::from_opcode(opcode);
+    let address = opcode as u8;
+    let source = AddressingMode::Direct { bank, address };
+
+    let dest = AddressingMode::ACCUMULATOR_REGISTER;
+
+    execute_load(svp, rom, source, dest);
+}
+
+fn ld_addr_a(svp: &mut Svp, rom: &[u8], opcode: u16) {
+    let bank = RamBank::from_opcode(opcode);
+    let address = opcode as u8;
+    let dest = AddressingMode::Direct { bank, address };
+
+    let source = AddressingMode::ACCUMULATOR_REGISTER;
+
+    execute_load(svp, rom, source, dest);
+}
+
+fn ldi_d_imm(svp: &mut Svp, rom: &[u8], opcode: u16) {
+    let source = AddressingMode::Immediate;
+    let dest = AddressingMode::GeneralRegister((opcode >> 4) & 0xF);
+    execute_load(svp, rom, source, dest);
+}
+
+fn ldi_ri_imm(svp: &mut Svp, rom: &[u8], opcode: u16) {
+    let bank = RamBank::from_opcode(opcode);
+    let pointer = opcode & 0x03;
+    let modifier = (opcode >> 2) & 0x03;
+    let dest = AddressingMode::Indirect { bank, pointer, modifier };
+
+    let source = AddressingMode::Immediate;
+
+    execute_load(svp, rom, source, dest);
+}
+
+fn ldi_ri_simm(svp: &mut Svp, rom: &[u8], opcode: u16) {
+    let source = AddressingMode::ShortImmediate(opcode as u8);
+
+    let bank = if opcode.bit(10) { RamBank::One } else { RamBank::Zero };
+    let pointer = (opcode >> 8) & 0x03;
+    let dest = AddressingMode::PointerRegister(bank, pointer);
+
+    execute_load(svp, rom, source, dest);
+}
+
+fn ld_d_a_indirect(svp: &mut Svp, rom: &[u8], opcode: u16) {
+    let source = AddressingMode::AccumulatorIndirect;
+    let dest = AddressingMode::GeneralRegister((opcode >> 4) & 0xF);
+    execute_load(svp, rom, source, dest);
+}
+
+fn parse_alu_addressing_mode(opcode: u16) -> AddressingMode {
+    match opcode & 0x1F00 {
+        0x0000 => {
+            // OP A, s
+            AddressingMode::GeneralRegister(opcode & 0xF)
+        }
+        0x0200 | 0x0300 => {
+            // OP A, (ri)
+            let bank = RamBank::from_opcode(opcode);
+            let pointer = opcode & 0x03;
+            let modifier = (opcode >> 2) & 0x03;
+            AddressingMode::Indirect { bank, pointer, modifier }
+        }
+        0x0600 | 0x0700 => {
+            // OP A, addr
+            let bank = RamBank::from_opcode(opcode);
+            let address = opcode as u8;
+            AddressingMode::Direct { bank, address }
+        }
+        0x0800 => {
+            // OPi A, imm
+            AddressingMode::Immediate
+        }
+        0x0A00 | 0x0B00 => {
+            // OP A, ((ri))
+            let bank = RamBank::from_opcode(opcode);
+            let pointer = opcode & 0x03;
+            let modifier = (opcode >> 2) & 0x03;
+            AddressingMode::DoubleIndirect { bank, pointer, modifier }
+        }
+        0x1200 | 0x1300 => {
+            // OP A, ri
+            let bank = RamBank::from_opcode(opcode);
+            let pointer = opcode & 0x03;
+            AddressingMode::PointerRegister(bank, pointer)
+        }
+        0x1800 => {
+            // OPi A, simm
+            let immediate_value = opcode as u8;
+            AddressingMode::ShortImmediate(immediate_value)
+        }
+        _ => panic!("Invalid SVP opcode: {opcode:04X}"),
+    }
+}
+
+fn read_addressing_mode(svp: &mut Svp, rom: &[u8], source: AddressingMode) -> u16 {
+    match source {
+        AddressingMode::GeneralRegister(register) => read_register(svp, rom, register),
+        AddressingMode::PointerRegister(bank, register) => match (bank, register) {
+            (RamBank::Zero, 0..=2) => svp.registers.ram0_pointers[register as usize].into(),
+            (RamBank::One, 0..=2) => svp.registers.ram1_pointers[register as usize].into(),
+            (RamBank::Zero | RamBank::One, 3) => 0,
+            _ => panic!("invalid pointer register: {register}"),
+        },
+        AddressingMode::Indirect { bank, pointer, modifier } => {
+            let ram_addr = read_pointer(svp, bank, pointer, modifier);
+            match bank {
+                RamBank::Zero => svp.ram0[ram_addr as usize],
+                RamBank::One => svp.ram1[ram_addr as usize],
+            }
+        }
+        AddressingMode::DoubleIndirect { bank, pointer, modifier } => {
+            let ram_addr = read_pointer(svp, bank, pointer, modifier);
+            let ram = match bank {
+                RamBank::Zero => &mut svp.ram0,
+                RamBank::One => &mut svp.ram1,
+            };
+
+            let indirect_addr = ram[ram_addr as usize];
+            ram[ram_addr as usize] = indirect_addr.wrapping_add(1);
+
+            log::trace!("  Indirect addr = {indirect_addr:04X}");
+
+            svp.read_program_memory(indirect_addr, rom)
+        }
+        AddressingMode::Direct { bank, address } => match bank {
+            RamBank::Zero => svp.ram0[address as usize],
+            RamBank::One => svp.ram1[address as usize],
+        },
+        AddressingMode::Immediate => {
+            let value = fetch_operand(svp, rom);
+            log::trace!("  Immediate value: {value:04X}");
+            value
+        }
+        AddressingMode::ShortImmediate(value) => value.into(),
+        AddressingMode::AccumulatorIndirect => {
+            let address = (svp.registers.accumulator >> 16) as u16;
+            svp.read_program_memory(address, rom)
+        }
+    }
+}
+
+fn write_addressing_mode(svp: &mut Svp, dest: AddressingMode, value: u16) {
+    match dest {
+        AddressingMode::GeneralRegister(register) => {
+            write_register(svp, register, value);
+        }
+        AddressingMode::PointerRegister(bank, pointer) => {
+            if pointer < 3 {
+                match bank {
+                    RamBank::Zero => {
+                        svp.registers.ram0_pointers[pointer as usize] = value as u8;
+                    }
+                    RamBank::One => {
+                        svp.registers.ram1_pointers[pointer as usize] = value as u8;
+                    }
+                }
+            }
+        }
+        AddressingMode::Indirect { bank, pointer, modifier } => {
+            let ram_addr = read_pointer(svp, bank, pointer, modifier);
+            match bank {
+                RamBank::Zero => {
+                    svp.ram0[ram_addr as usize] = value;
+                }
+                RamBank::One => {
+                    svp.ram1[ram_addr as usize] = value;
+                }
+            }
+        }
+        AddressingMode::Direct { bank, address } => match bank {
+            RamBank::Zero => {
+                svp.ram0[address as usize] = value;
+            }
+            RamBank::One => {
+                svp.ram1[address as usize] = value;
+            }
+        },
+        AddressingMode::DoubleIndirect { .. }
+        | AddressingMode::Immediate
+        | AddressingMode::ShortImmediate(..)
+        | AddressingMode::AccumulatorIndirect => panic!("Invalid write addressing mode: {dest:?}"),
+    }
+}
+
+#[allow(clippy::match_same_arms)]
+fn read_register(svp: &mut Svp, rom: &[u8], register: u16) -> u16 {
+    match register {
+        0 => {
+            // Dummy register; always reads $FFFF
+            0xFFFF
+        }
+        1 => {
+            // X register
+            svp.registers.x
+        }
+        2 => {
+            // Y register
+            svp.registers.y
+        }
+        3 => {
+            // Accumulator, high word
+            (svp.registers.accumulator >> 16) as u16
+        }
+        4 => {
+            // Status register
+            svp.registers.status.into()
+        }
+        5 => {
+            // Stack register; reads pop
+            svp.registers.stack.pop()
+        }
+        6 => {
+            // PC
+            svp.registers.pc
+        }
+        7 => {
+            // P register
+            (svp.registers.product() >> 16) as u16
+        }
+        8 => {
+            // PM0 / XST status
+            if svp.registers.status.st_bits_set() {
+                // PM0
+                pm_read(svp, rom, 0)
+            } else {
+                // XST status
+                svp.registers.xst.ssp_read_status()
+            }
+        }
+        9 => {
+            // PM1
+            pm_read(svp, rom, 1)
+        }
+        10 => {
+            // PM2
+            pm_read(svp, rom, 2)
+        }
+        11 => {
+            // PM3 / XST register
+            if svp.registers.status.st_bits_set() {
+                // PM3
+                pm_read(svp, rom, 3)
+            } else {
+                // XST register
+                svp.registers.xst.value
+            }
+        }
+        12 => {
+            // PM4
+            pm_read(svp, rom, 4)
+        }
+        13 => {
+            // Unknown; unused by SVP code
+            0xFFFF
+        }
+        14 => {
+            // PMC register
+            log::trace!("PMC read");
+            svp.registers.pmc.read()
+        }
+        15 => {
+            // Accumulator, low word
+            svp.registers.accumulator as u16
+        }
+        _ => panic!("Invalid SVP register number: {register}"),
+    }
+}
+
+#[allow(clippy::match_same_arms)]
+fn write_register(svp: &mut Svp, register: u16, value: u16) {
+    match register {
+        0 => {
+            // Dummy register; writes do nothing
+        }
+        1 => {
+            // X register
+            svp.registers.x = value;
+        }
+        2 => {
+            // Y register
+            svp.registers.y = value;
+        }
+        3 => {
+            // Accumulator, high word
+            svp.registers.accumulator =
+                (svp.registers.accumulator & 0x0000_FFFF) | (u32::from(value) << 16);
+        }
+        4 => {
+            // Status register
+            svp.registers.status.write(value);
+        }
+        5 => {
+            // Stack; writes push
+            svp.registers.stack.push(value);
+        }
+        6 => {
+            // PC
+            svp.registers.pc = value;
+        }
+        7 => {
+            // P register; writes do nothing because P always equals 2 * X * Y
+        }
+        8 => {
+            // PM0 / XST status
+            if svp.registers.status.st_bits_set() {
+                pm_write(svp, 0, value);
+            } else {
+                // is this even writable?
+                svp.registers.xst.m68k_written = value.bit(1);
+                svp.registers.xst.ssp_written = value.bit(0);
+            }
+        }
+        9 => {
+            // PM1
+            pm_write(svp, 1, value);
+        }
+        10 => {
+            // PM2
+            pm_write(svp, 2, value);
+        }
+        11 => {
+            // PM3 / XST register
+            if svp.registers.status.st_bits_set() {
+                // PM3
+                pm_write(svp, 3, value);
+            } else {
+                svp.registers.xst.ssp_write(value);
+            }
+        }
+        12 => {
+            // PM4
+            pm_write(svp, 4, value);
+        }
+        13 => {
+            // Unknown; unused by SVP
+        }
+        14 => {
+            // PMC
+            log::trace!("PMC write: {value:04X}");
+            svp.registers.pmc.write(value);
+        }
+        15 => {
+            // Accumulator, low word
+            svp.registers.accumulator =
+                (svp.registers.accumulator & 0xFFFF_0000) | u32::from(value);
+        }
+        _ => panic!("Invalid SVP register number: {register}"),
+    }
+}
+
+fn pm_read(svp: &mut Svp, rom: &[u8], pm_idx: usize) -> u16 {
+    log::trace!("PM{pm_idx} read");
+
+    let pm_register = &mut svp.registers.pm_read[pm_idx];
+    let address = pm_register.get_and_increment_address();
+
+    svp.registers.pmc.update_from(pm_register);
+
+    svp.read_external_memory(address, rom)
+}
+
+fn pm_write(svp: &mut Svp, pm_idx: usize, value: u16) {
+    log::trace!("PM{pm_idx} write {value:04X}");
+
+    let pm_register = &mut svp.registers.pm_write[pm_idx];
+    let address = pm_register.get_and_increment_address();
+    let overwrite_mode = pm_register.overwrite_mode;
+
+    svp.registers.pmc.update_from(pm_register);
+
+    if overwrite_mode {
+        // This is a read-modify-write, so verify that the SSP isn't attempting to write to ROM
+        if !(0x000000..=0x0FFFFF).contains(&address) {
+            let existing_value = svp.read_external_memory(address, &[]);
+
+            let new_value = [0x000F, 0x00F0, 0x0F00, 0xF000]
+                .into_iter()
+                .map(|mask| if value & mask != 0 { value & mask } else { existing_value & mask })
+                .reduce(|a, b| a | b)
+                .unwrap();
+            svp.write_external_memory(address, new_value);
+        }
+    } else {
+        svp.write_external_memory(address, value);
+    }
+}
+
+fn read_pointer(svp: &mut Svp, bank: RamBank, pointer: u16, modifier: u16) -> u8 {
+    if pointer < 3 {
+        let registers = match bank {
+            RamBank::Zero => &mut svp.registers.ram0_pointers,
+            RamBank::One => &mut svp.registers.ram1_pointers,
+        };
+
+        let ram_addr = registers[pointer as usize];
+        increment_pointer_register(
+            &mut registers[pointer as usize],
+            modifier,
+            svp.registers.status.loop_modulo(),
+        );
+        ram_addr
+    } else {
+        modifier as u8
+    }
+}
+
+fn increment_pointer_register(register: &mut u8, modifier: u16, loop_modulo: u8) {
+    match modifier {
+        0 => {}
+        1 => {
+            *register = (*register).wrapping_add(1);
+        }
+        2 => {
+            *register = modulo_decrement(*register, loop_modulo);
+        }
+        3 => {
+            *register = modulo_increment(*register, loop_modulo);
+        }
+        _ => panic!("invalid pointer register modifier: {modifier}"),
+    }
+}
+
+fn modulo_increment(value: u8, modulo: u8) -> u8 {
+    let mask = modulo.wrapping_sub(1);
+    (value & !mask) | (value.wrapping_add(1) & mask)
+}
+
+fn modulo_decrement(value: u8, modulo: u8) -> u8 {
+    let mask = modulo.wrapping_sub(1);
+    (value & !mask) | (value.wrapping_sub(1) & mask)
+}


### PR DESCRIPTION
The Sega Virtua Processor (SVP) chip was special cartridge hardware used in the Genesis port of  _Virtua Racing_ in order to render 3D graphics on a console that was otherwise nowhere near capable of 3D. It was not used in any other games as Sega decided to shift their focus to the 32X and later the Saturn.

The primary component inside the SVP is an SSP1601 DSP clocked around 23 MHz, capable of extremely fast (for the time) ALU and multiply-accumulate operations. The cartridge also contains 128KB of DRAM that the DSP uses for model inputs and for rendering, as well as 2KB of executable "IRAM" (instruction RAM) that the DSP can write short programs into.

The cartridge ROM contains a software renderer that uses the DSP to render 3D models into DRAM, with output in the Genesis VDP's tile format. Once a rendering operation is complete, the 68000 initiates a VDP DMA to copy the tiles into VRAM (similar to how the Sega CD's rotation/scaling works).

This implementation is pretty much entirely based on documentation and reverse engineering work by notaz and Tasco Deluxe:
https://notaz.gp2x.de/docs/svpdoc.txt

![Screenshot from 2023-10-12 17-38-40](https://github.com/jsgroth/jgenesis/assets/1137683/5c84afb7-df69-4f11-b46c-c53f1fa834e4)
