### PR TITLE
Implement SNES CX4 coprocessor

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Cross-platform multi-console emulator that supports the Sega Genesis / Mega Driv
   * Sega Master System / Mark III
   * Game Gear
   * Super Nintendo Entertainment System (SNES) / Super Famicom
-    * No coprocessors are currently implemented (Super FX, SA-1, CX4, etc.), and any games that used them will not currently work
+    * Most coprocessors are not currently implemented (Super FX, SA-1, etc.), and any games that used them will not currently work
 * GPU-based renderer with integer prescaling and optional linear interpolation
 * Configurable pixel aspect ratio for each console with several different options: accurate to original hardware/TVs, square pixels, and stretched to fill the window
 * Support for the Sega Master System FM sound unit expansion

--- a/jgenesis-common/src/num.rs
+++ b/jgenesis-common/src/num.rs
@@ -17,10 +17,13 @@ macro_rules! impl_get_bit {
 impl_get_bit!(u8, 8);
 impl_get_bit!(u16, 16);
 impl_get_bit!(u32, 32);
+impl_get_bit!(u64, 64);
+impl_get_bit!(usize, usize::BITS as u8);
 
 impl_get_bit!(i8, 8);
 impl_get_bit!(i16, 16);
 impl_get_bit!(i32, 32);
+impl_get_bit!(i64, 64);
 
 pub trait SignBit: Copy {
     fn sign_bit(self) -> bool;
@@ -40,7 +43,9 @@ macro_rules! impl_sign_bit {
 impl_sign_bit!(u8, 7);
 impl_sign_bit!(u16, 15);
 impl_sign_bit!(u32, 31);
+impl_sign_bit!(u64, 63);
 
 impl_sign_bit!(i8, 7);
 impl_sign_bit!(i16, 15);
 impl_sign_bit!(i32, 31);
+impl_sign_bit!(i64, 63);

--- a/snes-core/src/memory/cartridge/cx4.rs
+++ b/snes-core/src/memory/cartridge/cx4.rs
@@ -154,6 +154,10 @@ impl Cx4Registers {
                 // Program ROM instruction pointer + execute instruction
                 // TODO set busy bit?
                 self.instruction_pointer = value;
+
+                // The DSP obviously takes some time to complete the requested function, but
+                // MMX2 and MMX3 seem to work fine if all function calls complete instantly from the
+                // game's perspective
                 functions::execute(self, rom, ram);
             }
             0x7F50 => {
@@ -244,7 +248,7 @@ impl Cx4Registers {
             + (u32::from(self.instruction_pointer) << 1)
     }
 
-    fn increment_ip(&mut self) {
+    fn increment_instruction_pointer(&mut self) {
         self.instruction_pointer = self.instruction_pointer.wrapping_add(1);
     }
 }

--- a/snes-core/src/memory/cartridge/cx4.rs
+++ b/snes-core/src/memory/cartridge/cx4.rs
@@ -1,0 +1,317 @@
+mod functions;
+
+use crate::memory::cartridge;
+use crate::memory::cartridge::{CartridgeAddress, Rom};
+use bincode::{Decode, Encode};
+use jgenesis_proc_macros::PartialClone;
+use std::{cmp, mem};
+
+const RAM_LEN: usize = 3 * 1024;
+
+const LOROM_NMI_VECTOR: usize = 0x7FEA;
+const LOROM_IRQ_VECTOR: usize = 0x7FEE;
+
+type Cx4Ram = [u8; RAM_LEN];
+
+#[derive(Debug, Clone, Encode, Decode)]
+struct Cx4Registers {
+    // CX4's general-purpose registers (16x 24-bit)
+    gpr: [u32; 16],
+    dma_source_address: u32,
+    dma_destination_address: u16,
+    dma_length: u16,
+    program_rom_base: u32,
+    instruction_page: u16,
+    instruction_pointer: u8,
+    nmi_vector: u16,
+    irq_vector: u16,
+    // R/W registers with unknown functionality (MMX2/MMX3 always set them to fixed values)
+    unknown_register_7f50: u8,
+    unknown_register_7f51: u8,
+    unknown_register_7f52: u8,
+}
+
+impl Cx4Registers {
+    fn new(rom: &[u8]) -> Self {
+        // Pre-populate NMI and IRQ vectors with the values from ROM
+        let nmi_vector = u16::from_le_bytes([rom[LOROM_NMI_VECTOR], rom[LOROM_NMI_VECTOR + 1]]);
+        let irq_vector = u16::from_le_bytes([rom[LOROM_IRQ_VECTOR], rom[LOROM_IRQ_VECTOR + 1]]);
+        Self {
+            gpr: [0; 16],
+            dma_source_address: 0,
+            dma_destination_address: 0,
+            dma_length: 0,
+            program_rom_base: 0,
+            instruction_page: 0,
+            instruction_pointer: 0,
+            nmi_vector,
+            irq_vector,
+            unknown_register_7f50: 0,
+            unknown_register_7f51: 0,
+            unknown_register_7f52: 0,
+        }
+    }
+
+    fn read(&self, offset: u16) -> Option<u8> {
+        let value = match offset {
+            // Program ROM base, low byte
+            0x7F49 => self.program_rom_base as u8,
+            // Program ROM base, middle byte
+            0x7F4A => (self.program_rom_base >> 8) as u8,
+            // Program ROM base, high byte
+            0x7F4B => (self.program_rom_base >> 16) as u8,
+            // R/W registers with unknown functionality
+            0x7F50 => self.unknown_register_7f50,
+            0x7F51 => self.unknown_register_7f51,
+            0x7F52 => self.unknown_register_7f52,
+            // TODO should return busy bit in bit 6 after writing to $7F47/$7F48/$7F4F
+            0x7F5E => 0x00,
+            // NMI vector
+            0x7F6A => self.nmi_vector as u8,
+            0x7F6B => (self.nmi_vector >> 8) as u8,
+            // IRQ vector
+            0x7F6E => self.irq_vector as u8,
+            0x7F6F => (self.irq_vector >> 8) as u8,
+            // CX4 24-bit registers
+            0x7F80..=0x7FAF => self.read_24_bit_register(offset),
+            _ => {
+                log::info!("CX4 register read: {offset:04X}");
+                return None;
+            }
+        };
+
+        Some(value)
+    }
+
+    fn write(&mut self, offset: u16, value: u8, rom: &[u8], ram: &mut Cx4Ram) {
+        match offset {
+            0x7F40 => {
+                // DMA source address, low byte
+                self.dma_source_address =
+                    (self.dma_source_address & 0xFFFF_FF00) | u32::from(value);
+            }
+            0x7F41 => {
+                // DMA source address, middle byte
+                self.dma_source_address =
+                    (self.dma_source_address & 0xFFFF_00FF) | (u32::from(value) << 8);
+            }
+            0x7F42 => {
+                // DMA source address, high byte
+                self.dma_source_address =
+                    (self.dma_source_address & 0x0000_FFFF) | (u32::from(value) << 16);
+            }
+            0x7F43 => {
+                // DMA length, low byte
+                self.dma_length = (self.dma_length & 0xFF00) | u16::from(value);
+            }
+            0x7F44 => {
+                // DMA length, high byte
+                self.dma_length = (self.dma_length & 0x00FF) | (u16::from(value) << 8);
+            }
+            0x7F45 => {
+                // DMA destination, low byte
+                self.dma_destination_address =
+                    (self.dma_destination_address & 0xFF00) | u16::from(value);
+            }
+            0x7F46 => {
+                // DMA destination, high byte
+                self.dma_destination_address =
+                    (self.dma_destination_address & 0x00FF) | (u16::from(value) << 8);
+            }
+            0x7F47 => {
+                // Start ROM-to-CX4 DMA
+                if value == 0 {
+                    self.run_dma(rom, ram);
+                }
+            }
+            0x7F48 | 0x7F4C => {
+                // Write-only register with unknown functionality
+                // TODO set busy bit for $7F48
+            }
+            0x7F49 => {
+                // Program ROM base, low byte
+                self.program_rom_base = (self.program_rom_base & 0xFFFF_FF00) | u32::from(value);
+            }
+            0x7F4A => {
+                // Program ROM base, middle byte
+                self.program_rom_base =
+                    (self.program_rom_base & 0xFFFF_00FF) | (u32::from(value) << 8);
+            }
+            0x7F4B => {
+                // Program ROM base, high byte
+                self.program_rom_base =
+                    (self.program_rom_base & 0x0000_FFFF) | (u32::from(value) << 16);
+            }
+            0x7F4D => {
+                // Program ROM instruction page, low byte
+                self.instruction_page = (self.instruction_page & 0xFF00) | u16::from(value);
+            }
+            0x7F4E => {
+                // Program ROM instruction page, high byte
+                self.instruction_page = (self.instruction_page & 0x00FF) | (u16::from(value) << 8);
+            }
+            0x7F4F => {
+                // Program ROM instruction pointer + execute instruction
+                // TODO set busy bit?
+                self.instruction_pointer = value;
+                functions::execute(self, rom, ram);
+            }
+            0x7F50 => {
+                // R/W register with unknown functionality
+                self.unknown_register_7f50 = value;
+            }
+            0x7F51 => {
+                // R/W register with unknown functionality
+                self.unknown_register_7f51 = value;
+            }
+            0x7F52 => {
+                // R/W register with unknown functionality
+                self.unknown_register_7f52 = value;
+            }
+            0x7F6A => {
+                // NMI vector, low byte
+                self.nmi_vector = (self.nmi_vector & 0xFF00) | u16::from(value);
+            }
+            0x7F6B => {
+                // NMI vector, high byte
+                self.nmi_vector = (self.nmi_vector & 0x00FF) | (u16::from(value) << 8);
+            }
+            0x7F6E => {
+                // IRQ vector, low byte
+                self.irq_vector = (self.irq_vector & 0xFF00) | u16::from(value);
+            }
+            0x7F6F => {
+                // IRQ vector, high byte
+                self.irq_vector = (self.irq_vector & 0x00FF) | (u16::from(value) << 8);
+            }
+            0x7F80..=0x7FAF => {
+                // CX4 24-bit registers
+                self.write_24_bit_register(offset, value);
+            }
+            _ => {
+                log::info!("CX4 register write: {offset:04X} {value:02X}");
+            }
+        }
+    }
+
+    fn read_24_bit_register(&self, offset: u16) -> u8 {
+        let idx = (offset & 0x3F) / 3;
+        let shift = (offset % 3) * 8;
+        (self.gpr[idx as usize] >> shift) as u8
+    }
+
+    fn write_24_bit_register(&mut self, offset: u16, value: u8) {
+        let idx = (offset & 0x3F) / 3;
+        let (mask, shift) = match offset % 3 {
+            0 => (0xFFFF_FF00, 0),
+            1 => (0xFFFF_00FF, 8),
+            2 => (0x0000_FFFF, 16),
+            _ => panic!("value % 3 is always 0/1/2"),
+        };
+
+        let existing_value = self.gpr[idx as usize];
+        self.gpr[idx as usize] = (existing_value & mask) | (u32::from(value) << shift);
+    }
+
+    fn run_dma(&self, rom: &[u8], ram: &mut Cx4Ram) {
+        if !(0x6000..0x6C00).contains(&self.dma_destination_address) {
+            return;
+        }
+
+        log::trace!(
+            "Running DMA with src={:06X}, dst={:04X}, len={:04X}",
+            self.dma_source_address,
+            self.dma_destination_address,
+            self.dma_length
+        );
+
+        let mut src_addr = self.dma_source_address;
+        let mut dest_addr: u32 = (self.dma_destination_address - 0x6000).into();
+        let dma_len = cmp::min(0x0C00 - dest_addr, self.dma_length.into());
+
+        for _ in 0..dma_len {
+            let rom_addr = cartridge::lorom_map_rom_address(src_addr, rom.len() as u32);
+            ram[dest_addr as usize] = rom[rom_addr as usize];
+
+            src_addr = (src_addr + 1) & 0xFFFFFF;
+            dest_addr += 1;
+        }
+    }
+
+    fn risc_pc(&self) -> u32 {
+        self.program_rom_base
+            + (u32::from(self.instruction_page) << 9)
+            + (u32::from(self.instruction_pointer) << 1)
+    }
+
+    fn increment_ip(&mut self) {
+        self.instruction_pointer = self.instruction_pointer.wrapping_add(1);
+    }
+}
+
+#[derive(Debug, Clone, Encode, Decode, PartialClone)]
+pub struct Cx4 {
+    #[partial_clone(default)]
+    rom: Rom,
+    ram: Box<Cx4Ram>,
+    registers: Cx4Registers,
+}
+
+impl Cx4 {
+    pub fn new(rom: Rom) -> Self {
+        let registers = Cx4Registers::new(&rom);
+        Self { rom, ram: vec![0; RAM_LEN].into_boxed_slice().try_into().unwrap(), registers }
+    }
+
+    pub fn read(&self, address: u32) -> Option<u8> {
+        let bank = (address >> 16) as u8;
+        let offset = address as u16;
+        match (bank, offset) {
+            // NMI vector
+            (0x00, 0xFFEA) => Some(self.registers.nmi_vector as u8),
+            (0x00, 0xFFEB) => Some((self.registers.nmi_vector >> 8) as u8),
+            // IRQ vector
+            (0x00, 0xFFEE) => Some(self.registers.irq_vector as u8),
+            (0x00, 0xFFEF) => Some((self.registers.irq_vector >> 8) as u8),
+            // CX4 RAM (3KB)
+            (0x00..=0x3F | 0x80..=0xBF, 0x6000..=0x6BFF) => {
+                Some(self.ram[(address & 0xFFF) as usize])
+            }
+            // CX4 registers
+            (0x00..=0x3F | 0x80..=0xBF, 0x7F40..=0x7FAF) => self.registers.read(offset),
+            // SRAM range, which is unmapped in all CX4 games and always reads $00
+            (0x70..=0x77, _) => Some(0x00),
+            // Treat other addresses as LoROM
+            _ => match cartridge::lorom_map_address(address, self.rom.len() as u32, 0) {
+                CartridgeAddress::Rom(rom_addr) => Some(self.rom[rom_addr as usize]),
+                CartridgeAddress::None | CartridgeAddress::Sram(..) => None,
+            },
+        }
+    }
+
+    pub fn write(&mut self, address: u32, value: u8) {
+        let bank = (address >> 16) as u8;
+        let offset = address as u16;
+        match (bank, offset) {
+            // CX4 RAM (3KB)
+            (0x00..=0x3F | 0x80..=0xBF, 0x6000..=0x6BFF) => {
+                self.ram[(address & 0xFFF) as usize] = value;
+            }
+            // CX4 registers
+            (0x00..=0x3F | 0x80..=0xBF, 0x7F40..=0x7FAF) => {
+                self.registers.write(offset, value, &self.rom, &mut self.ram);
+            }
+            _ => {
+                log::info!("CX4 write: {address:06X} {value:02X}");
+            }
+        }
+    }
+
+    pub fn take_rom(&mut self) -> Vec<u8> {
+        mem::take(&mut self.rom.0).into_vec()
+    }
+
+    pub fn set_rom(&mut self, rom: Vec<u8>) {
+        self.rom.0 = rom.into_boxed_slice();
+    }
+}

--- a/snes-core/src/memory/cartridge/cx4/functions.rs
+++ b/snes-core/src/memory/cartridge/cx4/functions.rs
@@ -8,10 +8,13 @@ use jgenesis_common::num::GetBit;
 struct RiscRegisters {
     a: u32,
     m: i64,
-    snes_buffer: u8,
+    // Used for reading data from cartridge ROM
+    ext_buffer: u8,
+    ext_pointer: u32,
+    // Used for reading data from CX4 ROM
     rom_buffer: u32,
+    // Used for reading data from CX4 RAM
     ram_buffer: u32,
-    snes_pointer: u32,
     ram_pointer: u16,
     page: u16,
     zero: bool,
@@ -52,10 +55,11 @@ pub(super) fn execute(cx4_registers: &mut Cx4Registers, rom: &[u8], ram: &mut Cx
         let opcode_addr = cx4_registers.risc_pc();
         let rom_addr = cartridge::lorom_map_rom_address(opcode_addr, rom.len() as u32);
         let opcode = u16::from_le_bytes([rom[rom_addr as usize], rom[(rom_addr + 1) as usize]]);
-        cx4_registers.increment_ip();
+        cx4_registers.increment_instruction_pointer();
 
         log::trace!("opcode={opcode:04X}, PC={opcode_addr:06X}");
 
+        // The first 6 bits of opcode are enough to distinguish between instructions
         match opcode & 0xFC00 {
             0x0000 => {
                 // nop; do nothing
@@ -73,7 +77,7 @@ pub(super) fn execute(cx4_registers: &mut Cx4Registers, rom: &[u8], ram: &mut Cx
             0x3000 => callc(cx4_registers, &mut risc_registers, opcode),
             0x3400 => calln(cx4_registers, &mut risc_registers, opcode),
             0x3C00 => ret(cx4_registers, &mut risc_registers),
-            0x4000 => inc_snes_ptr(&mut risc_registers),
+            0x4000 => inc_ext_ptr(&mut risc_registers),
             0x4800 => cmpr_a_op(cx4_registers, &mut risc_registers, opcode),
             0x4C00 => cmpr_a_imm(&mut risc_registers, opcode),
             0x5000 => cmp_a_op(cx4_registers, &mut risc_registers, opcode),
@@ -138,11 +142,13 @@ pub(super) fn execute(cx4_registers: &mut Cx4Registers, rom: &[u8], ram: &mut Cx
 
 fn mov_a_imm(registers: &mut RiscRegisters, opcode: u16) {
     log::trace!("mov A, #${:02X}", opcode & 0xFF);
+
     registers.a = (opcode & 0xFF).into();
 }
 
 fn mov_a_op(cx4_registers: &Cx4Registers, risc_registers: &mut RiscRegisters, opcode: u16) {
     log::trace!("mov A, ${:02X}", opcode & 0xFF);
+
     risc_registers.a = read_register(cx4_registers, risc_registers, opcode) & 0xFFFFFF;
 }
 
@@ -153,35 +159,42 @@ fn mov_mbr_op(
     opcode: u16,
 ) {
     log::trace!("mov MBR, ${:02X}", opcode & 0xFF);
+
     let value = if opcode & 0xFF == 0x2E {
+        // $612E seems to be the only opcode that reads "register" $2E, which reads a byte from
+        // cartridge ROM using the current pointer
         let rom_addr =
-            cartridge::lorom_map_rom_address(risc_registers.snes_pointer, rom.len() as u32);
+            cartridge::lorom_map_rom_address(risc_registers.ext_pointer, rom.len() as u32);
         rom[rom_addr as usize]
     } else {
         read_register(cx4_registers, risc_registers, opcode) as u8
     };
-    risc_registers.snes_buffer = value;
+    risc_registers.ext_buffer = value;
 }
 
 fn mov_op_a(cx4_registers: &mut Cx4Registers, risc_registers: &mut RiscRegisters, opcode: u16) {
     log::trace!("mov ${:02X}, A", opcode & 0xFF);
+
     let a = risc_registers.a;
     write_register(cx4_registers, risc_registers, opcode, a);
 }
 
 fn mov_page_op(cx4_registers: &Cx4Registers, risc_registers: &mut RiscRegisters, opcode: u16) {
     log::trace!("mov page, {:02X}", opcode & 0xFF);
+
     let value = read_register(cx4_registers, risc_registers, opcode);
     risc_registers.page = value as u16;
 }
 
 fn mov_page_imm(registers: &mut RiscRegisters, opcode: u16) {
     log::trace!("mov page, #${:02X}", opcode & 0xFF);
+
     registers.page = opcode & 0xFF;
 }
 
 fn read_rom(cx4_registers: &Cx4Registers, risc_registers: &mut RiscRegisters, opcode: u16) {
     log::trace!("readrom ${:02X}", opcode & 0xFF);
+
     let address = read_register(cx4_registers, risc_registers, opcode);
     risc_registers.rom_buffer = rom::read(address);
 }
@@ -193,6 +206,7 @@ fn read_ram_op(
     opcode: u16,
 ) {
     log::trace!("readram ${:02X}", opcode & 0xFF);
+
     let address = read_register(cx4_registers, risc_registers, opcode);
     let value = ram.get((address & 0xFFF) as usize).copied().unwrap_or(0);
     read_ram(risc_registers, opcode, value);
@@ -200,6 +214,7 @@ fn read_ram_op(
 
 fn read_ram_imm(risc_registers: &mut RiscRegisters, ram: &Cx4Ram, opcode: u16) {
     log::trace!("readram #${:02X}", opcode & 0xFF);
+
     let address = risc_registers.ram_pointer.wrapping_add(opcode & 0xFF);
     let value = ram.get(address as usize).copied().unwrap_or(0);
     read_ram(risc_registers, opcode, value);
@@ -232,6 +247,7 @@ fn movb_ram_op(
     opcode: u16,
 ) {
     log::trace!("movb ram[${:02X}], ram_buf", opcode & 0xFF);
+
     let ram_addr = (read_register(cx4_registers, risc_registers, opcode) & 0xFFF) as usize;
     if ram_addr < ram.len() {
         let value = match opcode & 0x0300 {
@@ -249,6 +265,7 @@ fn movb_ram_op(
 
 fn movb_ram_ptr(registers: &RiscRegisters, ram: &mut Cx4Ram, opcode: u16) {
     log::trace!("movbram[ptr+#${:02X}], ram_buf", opcode & 0xFF);
+
     let ram_addr = (registers.ram_pointer.wrapping_add(opcode & 0xFF) & 0xFFF) as usize;
     if ram_addr < ram.len() {
         let value = match opcode & 0x0300 {
@@ -267,12 +284,14 @@ fn movb_ram_ptr(registers: &RiscRegisters, ram: &mut Cx4Ram, opcode: u16) {
 
 fn movb_page_op(cx4_registers: &Cx4Registers, risc_registers: &mut RiscRegisters, opcode: u16) {
     log::trace!("movb P, ${:02X}", opcode & 0xFF);
+
     let value = read_register(cx4_registers, risc_registers, opcode);
     mov_page(risc_registers, opcode, value as u8);
 }
 
 fn movb_page_imm(registers: &mut RiscRegisters, opcode: u16) {
     log::trace!("movb P, #${:02X}", opcode & 0xFF);
+
     mov_page(registers, opcode, opcode as u8);
 }
 
@@ -286,6 +305,7 @@ fn mov_page(registers: &mut RiscRegisters, opcode: u16, value: u8) {
 
 fn swap(cx4_registers: &mut Cx4Registers, risc_registers: &mut RiscRegisters, opcode: u16) {
     log::trace!("swap A, ${:02}", opcode & 0xFF);
+
     let old_a = risc_registers.a;
     risc_registers.a = read_register(cx4_registers, risc_registers, opcode);
     write_register(cx4_registers, risc_registers, opcode, old_a);
@@ -293,11 +313,13 @@ fn swap(cx4_registers: &mut Cx4Registers, risc_registers: &mut RiscRegisters, op
 
 fn jmp(cx4_registers: &mut Cx4Registers, risc_registers: &RiscRegisters, opcode: u16) {
     log::trace!("jmp {:02X}", opcode & 0xFF);
+
     execute_jump(cx4_registers, risc_registers, opcode);
 }
 
 fn jz(cx4_registers: &mut Cx4Registers, risc_registers: &RiscRegisters, opcode: u16) {
     log::trace!("jz {:02X}", opcode & 0xFF);
+
     if risc_registers.zero {
         execute_jump(cx4_registers, risc_registers, opcode);
     }
@@ -305,6 +327,7 @@ fn jz(cx4_registers: &mut Cx4Registers, risc_registers: &RiscRegisters, opcode: 
 
 fn jc(cx4_registers: &mut Cx4Registers, risc_registers: &RiscRegisters, opcode: u16) {
     log::trace!("jc {:02X}", opcode & 0xFF);
+
     if risc_registers.carry {
         execute_jump(cx4_registers, risc_registers, opcode);
     }
@@ -312,6 +335,7 @@ fn jc(cx4_registers: &mut Cx4Registers, risc_registers: &RiscRegisters, opcode: 
 
 fn jn(cx4_registers: &mut Cx4Registers, risc_registers: &RiscRegisters, opcode: u16) {
     log::trace!("jn {:02X}", opcode & 0xFF);
+
     if risc_registers.negative {
         execute_jump(cx4_registers, risc_registers, opcode);
     }
@@ -319,6 +343,7 @@ fn jn(cx4_registers: &mut Cx4Registers, risc_registers: &RiscRegisters, opcode: 
 
 fn call(cx4_registers: &mut Cx4Registers, risc_registers: &mut RiscRegisters, opcode: u16) {
     log::trace!("call {:02X}", opcode & 0xFF);
+
     risc_registers
         .push_call_stack(cx4_registers.instruction_page, cx4_registers.instruction_pointer);
     execute_jump(cx4_registers, risc_registers, opcode);
@@ -326,6 +351,7 @@ fn call(cx4_registers: &mut Cx4Registers, risc_registers: &mut RiscRegisters, op
 
 fn callz(cx4_registers: &mut Cx4Registers, risc_registers: &mut RiscRegisters, opcode: u16) {
     log::trace!("callz {:02X}", opcode & 0xFF);
+
     if risc_registers.zero {
         risc_registers
             .push_call_stack(cx4_registers.instruction_page, cx4_registers.instruction_pointer);
@@ -335,6 +361,7 @@ fn callz(cx4_registers: &mut Cx4Registers, risc_registers: &mut RiscRegisters, o
 
 fn callc(cx4_registers: &mut Cx4Registers, risc_registers: &mut RiscRegisters, opcode: u16) {
     log::trace!("callc {:02X}", opcode & 0xFF);
+
     if risc_registers.carry {
         risc_registers
             .push_call_stack(cx4_registers.instruction_page, cx4_registers.instruction_pointer);
@@ -344,6 +371,7 @@ fn callc(cx4_registers: &mut Cx4Registers, risc_registers: &mut RiscRegisters, o
 
 fn calln(cx4_registers: &mut Cx4Registers, risc_registers: &mut RiscRegisters, opcode: u16) {
     log::trace!("calln {:02X}", opcode & 0xFF);
+
     if risc_registers.negative {
         risc_registers
             .push_call_stack(cx4_registers.instruction_page, cx4_registers.instruction_pointer);
@@ -353,6 +381,7 @@ fn calln(cx4_registers: &mut Cx4Registers, risc_registers: &mut RiscRegisters, o
 
 fn ret(cx4_registers: &mut Cx4Registers, risc_registers: &mut RiscRegisters) {
     log::trace!("ret");
+
     let (page, pointer) = risc_registers.pull_call_stack();
     cx4_registers.instruction_page = page;
     cx4_registers.instruction_pointer = pointer;
@@ -367,6 +396,7 @@ fn execute_jump(cx4_registers: &mut Cx4Registers, risc_registers: &RiscRegisters
 
 fn skip(cx4_registers: &mut Cx4Registers, risc_registers: &RiscRegisters, opcode: u16) {
     log::trace!("skip, opcode={opcode:04X}");
+
     let value = opcode.bit(0);
     let flag = match opcode & 0x0300 {
         0x0100 => risc_registers.carry,
@@ -384,12 +414,14 @@ fn skip(cx4_registers: &mut Cx4Registers, risc_registers: &RiscRegisters, opcode
 
 fn add_a_op(cx4_registers: &Cx4Registers, risc_registers: &mut RiscRegisters, opcode: u16) {
     log::trace!("add A, ${:02X}", opcode & 0xFF);
+
     let value = read_register(cx4_registers, risc_registers, opcode);
     add(risc_registers, opcode, value);
 }
 
 fn add_a_imm(registers: &mut RiscRegisters, opcode: u16) {
     log::trace!("add A, #${:02X}", opcode & 0xFF);
+
     add(registers, opcode, (opcode & 0xFF).into());
 }
 
@@ -403,23 +435,27 @@ fn add(registers: &mut RiscRegisters, opcode: u16, value: u32) {
 
 fn subr_a_op(cx4_registers: &Cx4Registers, risc_registers: &mut RiscRegisters, opcode: u16) {
     log::trace!("subr A, ${:02X}", opcode & 0xFF);
+
     let value = read_register(cx4_registers, risc_registers, opcode);
     sub(risc_registers, opcode, value, true);
 }
 
 fn subr_a_imm(registers: &mut RiscRegisters, opcode: u16) {
     log::trace!("subr A, #${:02X}", opcode & 0xFF);
+
     sub(registers, opcode, (opcode & 0xFF).into(), true);
 }
 
 fn sub_a_op(cx4_registers: &Cx4Registers, risc_registers: &mut RiscRegisters, opcode: u16) {
     log::trace!("sub A, ${:02X}", opcode & 0xFF);
+
     let value = read_register(cx4_registers, risc_registers, opcode);
     sub(risc_registers, opcode, value, false);
 }
 
 fn sub_a_imm(registers: &mut RiscRegisters, opcode: u16) {
     log::trace!("sub A, #${:02X}", opcode & 0xFF);
+
     sub(registers, opcode, (opcode & 0xFF).into(), false);
 }
 
@@ -434,23 +470,27 @@ fn sub(registers: &mut RiscRegisters, opcode: u16, value: u32, reverse: bool) {
 
 fn cmpr_a_op(cx4_registers: &Cx4Registers, risc_registers: &mut RiscRegisters, opcode: u16) {
     log::trace!("cmpr A, ${:02X}", opcode & 0xFF);
+
     let value = read_register(cx4_registers, risc_registers, opcode);
     cmp(risc_registers, opcode, value, true);
 }
 
 fn cmpr_a_imm(registers: &mut RiscRegisters, opcode: u16) {
     log::trace!("cmpr A, #${:02X}", opcode & 0xFF);
+
     cmp(registers, opcode, (opcode & 0xFF).into(), true);
 }
 
 fn cmp_a_op(cx4_registers: &Cx4Registers, risc_registers: &mut RiscRegisters, opcode: u16) {
     log::trace!("cmp A, ${:02X}", opcode & 0xFF);
+
     let value = read_register(cx4_registers, risc_registers, opcode);
     cmp(risc_registers, opcode, value, false);
 }
 
 fn cmp_a_imm(registers: &mut RiscRegisters, opcode: u16) {
     log::trace!("cmp A, #${:02X}", opcode & 0xFF);
+
     cmp(registers, opcode, (opcode & 0xFF).into(), false);
 }
 
@@ -463,17 +503,22 @@ fn cmp(registers: &mut RiscRegisters, opcode: u16, value: u32, reverse: bool) {
 
 fn smul_op(cx4_registers: &Cx4Registers, risc_registers: &mut RiscRegisters, opcode: u16) {
     log::trace!("smul ${:02X}", opcode & 0xFF);
+
     let value = read_register(cx4_registers, risc_registers, opcode);
     smul(risc_registers, value);
 }
 
 fn smul_imm(registers: &mut RiscRegisters, opcode: u16) {
     log::trace!("smul #${:02X}", opcode & 0xFF);
+
     let value = (opcode & 0xFF).into();
     smul(registers, value);
 }
 
 fn smul(registers: &mut RiscRegisters, value: u32) {
+    // smul multiplies two signed 24-bit integers to produce a signed 48-bit result
+    // Simulate this by sign extending the 24-bit numbers to 64 bits and doing the multiplication
+    // in 64 bits
     let a = ((registers.a as i32) << 8) >> 8;
     let b = ((value as i32) << 8) >> 8;
     registers.m = i64::from(a) * i64::from(b);
@@ -481,12 +526,14 @@ fn smul(registers: &mut RiscRegisters, value: u32) {
 
 fn and_a_op(cx4_registers: &Cx4Registers, risc_registers: &mut RiscRegisters, opcode: u16) {
     log::trace!("and A, ${:02X}", opcode & 0xFF);
+
     let value = read_register(cx4_registers, risc_registers, opcode);
     and(risc_registers, opcode, value);
 }
 
 fn and_a_imm(registers: &mut RiscRegisters, opcode: u16) {
     log::trace!("and A, #${:02X}", opcode & 0xFF);
+
     and(registers, opcode, (opcode & 0xFF).into());
 }
 
@@ -499,12 +546,14 @@ fn and(registers: &mut RiscRegisters, opcode: u16, value: u32) {
 
 fn or_a_op(cx4_registers: &Cx4Registers, risc_registers: &mut RiscRegisters, opcode: u16) {
     log::trace!("or A, ${:02X}", opcode & 0xFF);
+
     let value = read_register(cx4_registers, risc_registers, opcode);
     or(risc_registers, opcode, value);
 }
 
 fn or_a_imm(registers: &mut RiscRegisters, opcode: u16) {
     log::trace!("or A, #${:02X}", opcode & 0xFF);
+
     or(registers, opcode, (opcode & 0xFF).into());
 }
 
@@ -517,12 +566,14 @@ fn or(registers: &mut RiscRegisters, opcode: u16, value: u32) {
 
 fn xor_a_op(cx4_registers: &Cx4Registers, risc_registers: &mut RiscRegisters, opcode: u16) {
     log::trace!("xor A, ${:02X}", opcode & 0xFF);
+
     let value = read_register(cx4_registers, risc_registers, opcode);
     xor(risc_registers, opcode, value);
 }
 
 fn xor_a_imm(risc_registers: &mut RiscRegisters, opcode: u16) {
     log::trace!("xor A, #${:02X}", opcode & 0xFF);
+
     xor(risc_registers, opcode, (opcode & 0xFF).into());
 }
 
@@ -535,12 +586,14 @@ fn xor(registers: &mut RiscRegisters, opcode: u16, value: u32) {
 
 fn shr_a_op(cx4_registers: &Cx4Registers, risc_registers: &mut RiscRegisters, opcode: u16) {
     log::trace!("shr ${:02X}", opcode & 0xFF);
+
     let value = read_register(cx4_registers, risc_registers, opcode);
     shr(risc_registers, value);
 }
 
 fn shr_a_imm(registers: &mut RiscRegisters, opcode: u16) {
     log::trace!("shr #${:02X}", opcode & 0xFF);
+
     shr(registers, (opcode & 0x1F).into());
 }
 
@@ -553,12 +606,14 @@ fn shr(registers: &mut RiscRegisters, value: u32) {
 
 fn sar_a_op(cx4_registers: &Cx4Registers, risc_registers: &mut RiscRegisters, opcode: u16) {
     log::trace!("sar ${:02X}", opcode & 0xFF);
+
     let value = read_register(cx4_registers, risc_registers, opcode);
     sar(risc_registers, value);
 }
 
 fn sar_a_imm(registers: &mut RiscRegisters, opcode: u16) {
     log::trace!("sar #${:02X}", opcode & 0xFF);
+
     sar(registers, (opcode & 0x1F).into());
 }
 
@@ -571,12 +626,14 @@ fn sar(registers: &mut RiscRegisters, value: u32) {
 
 fn shl_a_op(cx4_registers: &Cx4Registers, risc_registers: &mut RiscRegisters, opcode: u16) {
     log::trace!("shl ${:02X}", opcode & 0xFF);
+
     let value = read_register(cx4_registers, risc_registers, opcode);
     shl(risc_registers, value);
 }
 
 fn shl_a_imm(registers: &mut RiscRegisters, opcode: u16) {
     log::trace!("shl #${:02X}", opcode & 0xFF);
+
     shl(registers, (opcode & 0x1F).into());
 }
 
@@ -589,12 +646,14 @@ fn shl(registers: &mut RiscRegisters, value: u32) {
 
 fn ror_a_op(cx4_registers: &Cx4Registers, risc_registers: &mut RiscRegisters, opcode: u16) {
     log::trace!("ror ${:02X}", opcode & 0xFF);
+
     let value = read_register(cx4_registers, risc_registers, opcode);
     ror(risc_registers, value);
 }
 
 fn ror_a_imm(registers: &mut RiscRegisters, opcode: u16) {
     log::trace!("ror #${:02X}", opcode & 0xFF);
+
     ror(registers, (opcode & 0x1F).into());
 }
 
@@ -607,6 +666,7 @@ fn ror(registers: &mut RiscRegisters, value: u32) {
 
 fn sign_extend(registers: &mut RiscRegisters, opcode: u16) {
     log::trace!("exts, opcode={opcode:04X}");
+
     match opcode & 0x0300 {
         0x0100 => {
             registers.a = ((registers.a as i8) as u32) & 0xFFFFFF;
@@ -621,9 +681,10 @@ fn sign_extend(registers: &mut RiscRegisters, opcode: u16) {
     registers.set_nz(registers.a);
 }
 
-fn inc_snes_ptr(registers: &mut RiscRegisters) {
+fn inc_ext_ptr(registers: &mut RiscRegisters) {
     log::trace!("inc MAR");
-    registers.snes_pointer = (registers.snes_pointer + 1) & 0xFFFFFF;
+
+    registers.ext_pointer = (registers.ext_pointer + 1) & 0xFFFFFF;
 }
 
 fn apply_a_shift(a: u32, opcode: u16) -> u32 {
@@ -636,38 +697,26 @@ fn apply_a_shift(a: u32, opcode: u16) -> u32 {
     }
 }
 
+const CONSTANT_REGISTERS: &[u32; 16] = &[
+    0x000000, 0xFFFFFF, 0x00FF00, 0xFF0000, 0x00FFFF, 0xFFFF00, 0x800000, 0x7FFFFF, 0x008000,
+    0x007FFF, 0xFF7FFF, 0xFFFF7F, 0x010000, 0xFEFFFF, 0x000100, 0x00FEFF,
+];
+
 fn read_register(cx4_registers: &Cx4Registers, risc_registers: &RiscRegisters, opcode: u16) -> u32 {
     match opcode & 0xFF {
         0x00 => risc_registers.a,
         0x01 => ((risc_registers.m >> 24) as u32) & 0xFFFFFF,
         0x02 => (risc_registers.m as u32) & 0xFFFFFF,
-        0x03 => risc_registers.snes_buffer.into(),
+        0x03 => risc_registers.ext_buffer.into(),
         0x08 => risc_registers.rom_buffer,
         0x0C => risc_registers.ram_buffer,
-        0x13 => risc_registers.snes_pointer,
+        0x13 => risc_registers.ext_pointer,
         0x1C => risc_registers.ram_pointer.into(),
         0x20 => cx4_registers.instruction_pointer.into(),
         0x28 => risc_registers.page.into(),
-        0x50 => 0x000000,
-        0x51 => 0xFFFFFF,
-        0x52 => 0x00FF00,
-        0x53 => 0xFF0000,
-        0x54 => 0x00FFFF,
-        0x55 => 0xFFFF00,
-        0x56 => 0x800000,
-        0x57 => 0x7FFFFF,
-        0x58 => 0x008000,
-        0x59 => 0x007FFF,
-        0x5A => 0xFF7FFF,
-        0x5B => 0xFFFF7F,
-        0x5C => 0x010000,
-        0x5D => 0xFEFFFF,
-        0x5E => 0x000100,
-        0x5F => 0x00FEFF,
-        0x60..=0x6F => {
-            let register_idx = (opcode & 0xF) as usize;
-            cx4_registers.gpr[register_idx]
-        }
+        // $50-$5F are "fake" registers that always read constant values
+        0x50..=0x5F => CONSTANT_REGISTERS[(opcode & 0xF) as usize],
+        0x60..=0x6F => cx4_registers.gpr[(opcode & 0xF) as usize],
         _ => {
             log::warn!("Unhandled CX4 coprocessor register read: {:02X}", opcode & 0xFF);
             0x00
@@ -686,13 +735,13 @@ fn write_register(
             risc_registers.a = value;
         }
         0x03 => {
-            risc_registers.snes_buffer = value as u8;
+            risc_registers.ext_buffer = value as u8;
         }
         0x0C => {
             risc_registers.ram_buffer = value & 0xFFFFFF;
         }
         0x13 => {
-            risc_registers.snes_pointer = value & 0xFFFFFF;
+            risc_registers.ext_pointer = value & 0xFFFFFF;
         }
         0x1C => {
             risc_registers.ram_pointer = (value & 0xFFF) as u16;

--- a/snes-core/src/memory/cartridge/cx4/functions.rs
+++ b/snes-core/src/memory/cartridge/cx4/functions.rs
@@ -1,0 +1,714 @@
+mod rom;
+
+use crate::memory::cartridge;
+use crate::memory::cartridge::cx4::{Cx4Ram, Cx4Registers};
+use jgenesis_common::num::GetBit;
+
+#[derive(Debug, Clone, Default)]
+struct RiscRegisters {
+    a: u32,
+    m: i64,
+    snes_buffer: u8,
+    rom_buffer: u32,
+    ram_buffer: u32,
+    snes_pointer: u32,
+    ram_pointer: u16,
+    page: u16,
+    zero: bool,
+    negative: bool,
+    carry: bool,
+    call_stack: [(u16, u8); 16],
+    call_stack_ptr: u8,
+}
+
+impl RiscRegisters {
+    fn push_call_stack(&mut self, page: u16, pointer: u8) {
+        self.call_stack[self.call_stack_ptr as usize] = (page, pointer);
+        self.call_stack_ptr = (self.call_stack_ptr + 1) & 0xF;
+    }
+
+    fn pull_call_stack(&mut self) -> (u16, u8) {
+        self.call_stack_ptr = self.call_stack_ptr.wrapping_sub(1) & 0xF;
+        self.call_stack[self.call_stack_ptr as usize]
+    }
+
+    fn set_nz(&mut self, value: u32) {
+        self.zero = value & 0xFFFFFF == 0;
+        self.negative = value.bit(23);
+    }
+}
+
+#[allow(clippy::match_same_arms)]
+pub(super) fn execute(cx4_registers: &mut Cx4Registers, rom: &[u8], ram: &mut Cx4Ram) {
+    let mut risc_registers = RiscRegisters::default();
+
+    log::trace!(
+        "Beginning execution with page {:04X} and pointer {:02X}",
+        cx4_registers.instruction_page,
+        cx4_registers.instruction_pointer
+    );
+
+    loop {
+        let opcode_addr = cx4_registers.risc_pc();
+        let rom_addr = cartridge::lorom_map_rom_address(opcode_addr, rom.len() as u32);
+        let opcode = u16::from_le_bytes([rom[rom_addr as usize], rom[(rom_addr + 1) as usize]]);
+        cx4_registers.increment_ip();
+
+        log::trace!("opcode={opcode:04X}, PC={opcode_addr:06X}");
+
+        match opcode & 0xFC00 {
+            0x0000 => {
+                // nop; do nothing
+            }
+            0x0800 => jmp(cx4_registers, &risc_registers, opcode),
+            0x0C00 => jz(cx4_registers, &risc_registers, opcode),
+            0x1000 => jc(cx4_registers, &risc_registers, opcode),
+            0x1400 => jn(cx4_registers, &risc_registers, opcode),
+            0x1C00 => {
+                // "finish"; effectively does nothing, exists for timing purposes only?
+            }
+            0x2400 => skip(cx4_registers, &risc_registers, opcode),
+            0x2800 => call(cx4_registers, &mut risc_registers, opcode),
+            0x2C00 => callz(cx4_registers, &mut risc_registers, opcode),
+            0x3000 => callc(cx4_registers, &mut risc_registers, opcode),
+            0x3400 => calln(cx4_registers, &mut risc_registers, opcode),
+            0x3C00 => ret(cx4_registers, &mut risc_registers),
+            0x4000 => inc_snes_ptr(&mut risc_registers),
+            0x4800 => cmpr_a_op(cx4_registers, &mut risc_registers, opcode),
+            0x4C00 => cmpr_a_imm(&mut risc_registers, opcode),
+            0x5000 => cmp_a_op(cx4_registers, &mut risc_registers, opcode),
+            0x5400 => cmp_a_imm(&mut risc_registers, opcode),
+            0x5800 => sign_extend(&mut risc_registers, opcode),
+            0x6000 => match opcode & 0x0300 {
+                0x0000 => mov_a_op(cx4_registers, &mut risc_registers, opcode),
+                0x0100 => mov_mbr_op(cx4_registers, &mut risc_registers, rom, opcode),
+                0x0300 => mov_page_op(cx4_registers, &mut risc_registers, opcode),
+                _ => {
+                    log::warn!("Unexpected mov opcode: {opcode:04X}");
+                }
+            },
+            0x6400 => match opcode & 0x0300 {
+                0x0000 => mov_a_imm(&mut risc_registers, opcode),
+                0x0300 => mov_page_imm(&mut risc_registers, opcode),
+                _ => {
+                    log::warn!("Unexpected mov opcode: {opcode:04X}");
+                }
+            },
+            0x6800 => read_ram_op(cx4_registers, &mut risc_registers, ram, opcode),
+            0x6C00 => read_ram_imm(&mut risc_registers, ram, opcode),
+            0x7000 => read_rom(cx4_registers, &mut risc_registers, opcode),
+            0x7800 => movb_page_op(cx4_registers, &mut risc_registers, opcode),
+            0x7C00 => movb_page_imm(&mut risc_registers, opcode),
+            0x8000 => add_a_op(cx4_registers, &mut risc_registers, opcode),
+            0x8400 => add_a_imm(&mut risc_registers, opcode),
+            0x8800 => subr_a_op(cx4_registers, &mut risc_registers, opcode),
+            0x8C00 => subr_a_imm(&mut risc_registers, opcode),
+            0x9000 => sub_a_op(cx4_registers, &mut risc_registers, opcode),
+            0x9400 => sub_a_imm(&mut risc_registers, opcode),
+            0x9800 => smul_op(cx4_registers, &mut risc_registers, opcode),
+            0x9C00 => smul_imm(&mut risc_registers, opcode),
+            0xA800 => xor_a_op(cx4_registers, &mut risc_registers, opcode),
+            0xAC00 => xor_a_imm(&mut risc_registers, opcode),
+            0xB000 => and_a_op(cx4_registers, &mut risc_registers, opcode),
+            0xB400 => and_a_imm(&mut risc_registers, opcode),
+            0xB800 => or_a_op(cx4_registers, &mut risc_registers, opcode),
+            0xBC00 => or_a_imm(&mut risc_registers, opcode),
+            0xC000 => shr_a_op(cx4_registers, &mut risc_registers, opcode),
+            0xC400 => shr_a_imm(&mut risc_registers, opcode),
+            0xC800 => sar_a_op(cx4_registers, &mut risc_registers, opcode),
+            0xCC00 => sar_a_imm(&mut risc_registers, opcode),
+            0xD000 => ror_a_op(cx4_registers, &mut risc_registers, opcode),
+            0xD400 => ror_a_imm(&mut risc_registers, opcode),
+            0xD800 => shl_a_op(cx4_registers, &mut risc_registers, opcode),
+            0xDC00 => shl_a_imm(&mut risc_registers, opcode),
+            0xE000 => mov_op_a(cx4_registers, &mut risc_registers, opcode),
+            0xE800 => movb_ram_op(cx4_registers, &risc_registers, ram, opcode),
+            0xEC00 => movb_ram_ptr(&risc_registers, ram, opcode),
+            0xF000 => swap(cx4_registers, &mut risc_registers, opcode),
+            0xFC00 => {
+                // stop; function is complete
+                return;
+            }
+            _ => {
+                log::warn!("Unexpected opcode: {opcode:04X}");
+            }
+        }
+    }
+}
+
+fn mov_a_imm(registers: &mut RiscRegisters, opcode: u16) {
+    log::trace!("mov A, #${:02X}", opcode & 0xFF);
+    registers.a = (opcode & 0xFF).into();
+}
+
+fn mov_a_op(cx4_registers: &Cx4Registers, risc_registers: &mut RiscRegisters, opcode: u16) {
+    log::trace!("mov A, ${:02X}", opcode & 0xFF);
+    risc_registers.a = read_register(cx4_registers, risc_registers, opcode) & 0xFFFFFF;
+}
+
+fn mov_mbr_op(
+    cx4_registers: &Cx4Registers,
+    risc_registers: &mut RiscRegisters,
+    rom: &[u8],
+    opcode: u16,
+) {
+    log::trace!("mov MBR, ${:02X}", opcode & 0xFF);
+    let value = if opcode & 0xFF == 0x2E {
+        let rom_addr =
+            cartridge::lorom_map_rom_address(risc_registers.snes_pointer, rom.len() as u32);
+        rom[rom_addr as usize]
+    } else {
+        read_register(cx4_registers, risc_registers, opcode) as u8
+    };
+    risc_registers.snes_buffer = value;
+}
+
+fn mov_op_a(cx4_registers: &mut Cx4Registers, risc_registers: &mut RiscRegisters, opcode: u16) {
+    log::trace!("mov ${:02X}, A", opcode & 0xFF);
+    let a = risc_registers.a;
+    write_register(cx4_registers, risc_registers, opcode, a);
+}
+
+fn mov_page_op(cx4_registers: &Cx4Registers, risc_registers: &mut RiscRegisters, opcode: u16) {
+    log::trace!("mov page, {:02X}", opcode & 0xFF);
+    let value = read_register(cx4_registers, risc_registers, opcode);
+    risc_registers.page = value as u16;
+}
+
+fn mov_page_imm(registers: &mut RiscRegisters, opcode: u16) {
+    log::trace!("mov page, #${:02X}", opcode & 0xFF);
+    registers.page = opcode & 0xFF;
+}
+
+fn read_rom(cx4_registers: &Cx4Registers, risc_registers: &mut RiscRegisters, opcode: u16) {
+    log::trace!("readrom ${:02X}", opcode & 0xFF);
+    let address = read_register(cx4_registers, risc_registers, opcode);
+    risc_registers.rom_buffer = rom::read(address);
+}
+
+fn read_ram_op(
+    cx4_registers: &Cx4Registers,
+    risc_registers: &mut RiscRegisters,
+    ram: &Cx4Ram,
+    opcode: u16,
+) {
+    log::trace!("readram ${:02X}", opcode & 0xFF);
+    let address = read_register(cx4_registers, risc_registers, opcode);
+    let value = ram.get((address & 0xFFF) as usize).copied().unwrap_or(0);
+    read_ram(risc_registers, opcode, value);
+}
+
+fn read_ram_imm(risc_registers: &mut RiscRegisters, ram: &Cx4Ram, opcode: u16) {
+    log::trace!("readram #${:02X}", opcode & 0xFF);
+    let address = risc_registers.ram_pointer.wrapping_add(opcode & 0xFF);
+    let value = ram.get(address as usize).copied().unwrap_or(0);
+    read_ram(risc_registers, opcode, value);
+}
+
+fn read_ram(registers: &mut RiscRegisters, opcode: u16, ram_value: u8) {
+    match opcode & 0x0300 {
+        0x0000 => {
+            registers.ram_buffer = (registers.ram_buffer & 0xFFFF_FF00) | u32::from(ram_value);
+        }
+        0x0100 => {
+            registers.ram_buffer =
+                (registers.ram_buffer & 0xFFFF_00FF) | (u32::from(ram_value) << 8);
+        }
+        0x0200 => {
+            registers.ram_buffer =
+                (registers.ram_buffer & 0x0000_FFFF) | (u32::from(ram_value) << 16);
+        }
+        _ => {
+            log::warn!("Unexpected read RAM opcode: {opcode:04X}");
+        }
+    }
+    log::trace!("  read RAM value {ram_value}; RAM buffer is {:06X}", registers.ram_buffer);
+}
+
+fn movb_ram_op(
+    cx4_registers: &Cx4Registers,
+    risc_registers: &RiscRegisters,
+    ram: &mut Cx4Ram,
+    opcode: u16,
+) {
+    log::trace!("movb ram[${:02X}], ram_buf", opcode & 0xFF);
+    let ram_addr = (read_register(cx4_registers, risc_registers, opcode) & 0xFFF) as usize;
+    if ram_addr < ram.len() {
+        let value = match opcode & 0x0300 {
+            0x0000 => risc_registers.ram_buffer as u8,
+            0x0100 => (risc_registers.ram_buffer >> 8) as u8,
+            0x0200 => (risc_registers.ram_buffer >> 16) as u8,
+            _ => {
+                log::warn!("Unexpected movb RAM[..] opcode: {opcode:02X}");
+                0x00
+            }
+        };
+        ram[ram_addr] = value;
+    }
+}
+
+fn movb_ram_ptr(registers: &RiscRegisters, ram: &mut Cx4Ram, opcode: u16) {
+    log::trace!("movbram[ptr+#${:02X}], ram_buf", opcode & 0xFF);
+    let ram_addr = (registers.ram_pointer.wrapping_add(opcode & 0xFF) & 0xFFF) as usize;
+    if ram_addr < ram.len() {
+        let value = match opcode & 0x0300 {
+            0x0000 => registers.ram_buffer as u8,
+            0x0100 => (registers.ram_buffer >> 8) as u8,
+            0x0200 => (registers.ram_buffer >> 16) as u8,
+            _ => {
+                log::warn!("Unexpected movb RAM[..] opcode: {opcode:02X}");
+                0x00
+            }
+        };
+        ram[ram_addr] = value;
+        log::trace!("  wrote {value:02X} to {ram_addr:03X}");
+    }
+}
+
+fn movb_page_op(cx4_registers: &Cx4Registers, risc_registers: &mut RiscRegisters, opcode: u16) {
+    log::trace!("movb P, ${:02X}", opcode & 0xFF);
+    let value = read_register(cx4_registers, risc_registers, opcode);
+    mov_page(risc_registers, opcode, value as u8);
+}
+
+fn movb_page_imm(registers: &mut RiscRegisters, opcode: u16) {
+    log::trace!("movb P, #${:02X}", opcode & 0xFF);
+    mov_page(registers, opcode, opcode as u8);
+}
+
+fn mov_page(registers: &mut RiscRegisters, opcode: u16, value: u8) {
+    if !opcode.bit(8) {
+        registers.page = (registers.page & 0xFF00) | u16::from(value);
+    } else {
+        registers.page = (registers.page & 0x00FF) | (u16::from(value) << 8);
+    }
+}
+
+fn swap(cx4_registers: &mut Cx4Registers, risc_registers: &mut RiscRegisters, opcode: u16) {
+    log::trace!("swap A, ${:02}", opcode & 0xFF);
+    let old_a = risc_registers.a;
+    risc_registers.a = read_register(cx4_registers, risc_registers, opcode);
+    write_register(cx4_registers, risc_registers, opcode, old_a);
+}
+
+fn jmp(cx4_registers: &mut Cx4Registers, risc_registers: &RiscRegisters, opcode: u16) {
+    log::trace!("jmp {:02X}", opcode & 0xFF);
+    execute_jump(cx4_registers, risc_registers, opcode);
+}
+
+fn jz(cx4_registers: &mut Cx4Registers, risc_registers: &RiscRegisters, opcode: u16) {
+    log::trace!("jz {:02X}", opcode & 0xFF);
+    if risc_registers.zero {
+        execute_jump(cx4_registers, risc_registers, opcode);
+    }
+}
+
+fn jc(cx4_registers: &mut Cx4Registers, risc_registers: &RiscRegisters, opcode: u16) {
+    log::trace!("jc {:02X}", opcode & 0xFF);
+    if risc_registers.carry {
+        execute_jump(cx4_registers, risc_registers, opcode);
+    }
+}
+
+fn jn(cx4_registers: &mut Cx4Registers, risc_registers: &RiscRegisters, opcode: u16) {
+    log::trace!("jn {:02X}", opcode & 0xFF);
+    if risc_registers.negative {
+        execute_jump(cx4_registers, risc_registers, opcode);
+    }
+}
+
+fn call(cx4_registers: &mut Cx4Registers, risc_registers: &mut RiscRegisters, opcode: u16) {
+    log::trace!("call {:02X}", opcode & 0xFF);
+    risc_registers
+        .push_call_stack(cx4_registers.instruction_page, cx4_registers.instruction_pointer);
+    execute_jump(cx4_registers, risc_registers, opcode);
+}
+
+fn callz(cx4_registers: &mut Cx4Registers, risc_registers: &mut RiscRegisters, opcode: u16) {
+    log::trace!("callz {:02X}", opcode & 0xFF);
+    if risc_registers.zero {
+        risc_registers
+            .push_call_stack(cx4_registers.instruction_page, cx4_registers.instruction_pointer);
+        execute_jump(cx4_registers, risc_registers, opcode);
+    }
+}
+
+fn callc(cx4_registers: &mut Cx4Registers, risc_registers: &mut RiscRegisters, opcode: u16) {
+    log::trace!("callc {:02X}", opcode & 0xFF);
+    if risc_registers.carry {
+        risc_registers
+            .push_call_stack(cx4_registers.instruction_page, cx4_registers.instruction_pointer);
+        execute_jump(cx4_registers, risc_registers, opcode);
+    }
+}
+
+fn calln(cx4_registers: &mut Cx4Registers, risc_registers: &mut RiscRegisters, opcode: u16) {
+    log::trace!("calln {:02X}", opcode & 0xFF);
+    if risc_registers.negative {
+        risc_registers
+            .push_call_stack(cx4_registers.instruction_page, cx4_registers.instruction_pointer);
+        execute_jump(cx4_registers, risc_registers, opcode);
+    }
+}
+
+fn ret(cx4_registers: &mut Cx4Registers, risc_registers: &mut RiscRegisters) {
+    log::trace!("ret");
+    let (page, pointer) = risc_registers.pull_call_stack();
+    cx4_registers.instruction_page = page;
+    cx4_registers.instruction_pointer = pointer;
+}
+
+fn execute_jump(cx4_registers: &mut Cx4Registers, risc_registers: &RiscRegisters, opcode: u16) {
+    cx4_registers.instruction_pointer = opcode as u8;
+    if opcode.bit(9) {
+        cx4_registers.instruction_page = risc_registers.page;
+    }
+}
+
+fn skip(cx4_registers: &mut Cx4Registers, risc_registers: &RiscRegisters, opcode: u16) {
+    log::trace!("skip, opcode={opcode:04X}");
+    let value = opcode.bit(0);
+    let flag = match opcode & 0x0300 {
+        0x0100 => risc_registers.carry,
+        0x0200 => risc_registers.zero,
+        0x0300 => risc_registers.negative,
+        _ => {
+            log::warn!("Unexpected skip opcode: {opcode:02X}");
+            false
+        }
+    };
+    if flag == value {
+        cx4_registers.instruction_pointer = cx4_registers.instruction_pointer.wrapping_add(1);
+    }
+}
+
+fn add_a_op(cx4_registers: &Cx4Registers, risc_registers: &mut RiscRegisters, opcode: u16) {
+    log::trace!("add A, ${:02X}", opcode & 0xFF);
+    let value = read_register(cx4_registers, risc_registers, opcode);
+    add(risc_registers, opcode, value);
+}
+
+fn add_a_imm(registers: &mut RiscRegisters, opcode: u16) {
+    log::trace!("add A, #${:02X}", opcode & 0xFF);
+    add(registers, opcode, (opcode & 0xFF).into());
+}
+
+fn add(registers: &mut RiscRegisters, opcode: u16, value: u32) {
+    let result = apply_a_shift(registers.a, opcode) + value;
+    registers.set_nz(result);
+    registers.carry = result > 0xFFFFFF;
+
+    registers.a = result & 0xFFFFFF;
+}
+
+fn subr_a_op(cx4_registers: &Cx4Registers, risc_registers: &mut RiscRegisters, opcode: u16) {
+    log::trace!("subr A, ${:02X}", opcode & 0xFF);
+    let value = read_register(cx4_registers, risc_registers, opcode);
+    sub(risc_registers, opcode, value, true);
+}
+
+fn subr_a_imm(registers: &mut RiscRegisters, opcode: u16) {
+    log::trace!("subr A, #${:02X}", opcode & 0xFF);
+    sub(registers, opcode, (opcode & 0xFF).into(), true);
+}
+
+fn sub_a_op(cx4_registers: &Cx4Registers, risc_registers: &mut RiscRegisters, opcode: u16) {
+    log::trace!("sub A, ${:02X}", opcode & 0xFF);
+    let value = read_register(cx4_registers, risc_registers, opcode);
+    sub(risc_registers, opcode, value, false);
+}
+
+fn sub_a_imm(registers: &mut RiscRegisters, opcode: u16) {
+    log::trace!("sub A, #${:02X}", opcode & 0xFF);
+    sub(registers, opcode, (opcode & 0xFF).into(), false);
+}
+
+fn sub(registers: &mut RiscRegisters, opcode: u16, value: u32, reverse: bool) {
+    let a = apply_a_shift(registers.a, opcode);
+    let result = if reverse { value.wrapping_sub(a) } else { a.wrapping_sub(value) };
+    registers.set_nz(result);
+    registers.carry = result <= 0xFFFFFF;
+
+    registers.a = result & 0xFFFFFF;
+}
+
+fn cmpr_a_op(cx4_registers: &Cx4Registers, risc_registers: &mut RiscRegisters, opcode: u16) {
+    log::trace!("cmpr A, ${:02X}", opcode & 0xFF);
+    let value = read_register(cx4_registers, risc_registers, opcode);
+    cmp(risc_registers, opcode, value, true);
+}
+
+fn cmpr_a_imm(registers: &mut RiscRegisters, opcode: u16) {
+    log::trace!("cmpr A, #${:02X}", opcode & 0xFF);
+    cmp(registers, opcode, (opcode & 0xFF).into(), true);
+}
+
+fn cmp_a_op(cx4_registers: &Cx4Registers, risc_registers: &mut RiscRegisters, opcode: u16) {
+    log::trace!("cmp A, ${:02X}", opcode & 0xFF);
+    let value = read_register(cx4_registers, risc_registers, opcode);
+    cmp(risc_registers, opcode, value, false);
+}
+
+fn cmp_a_imm(registers: &mut RiscRegisters, opcode: u16) {
+    log::trace!("cmp A, #${:02X}", opcode & 0xFF);
+    cmp(registers, opcode, (opcode & 0xFF).into(), false);
+}
+
+fn cmp(registers: &mut RiscRegisters, opcode: u16, value: u32, reverse: bool) {
+    let a = apply_a_shift(registers.a, opcode);
+    let result = if reverse { value.wrapping_sub(a) } else { a.wrapping_sub(value) };
+    registers.set_nz(result);
+    registers.carry = result <= 0xFFFFFF;
+}
+
+fn smul_op(cx4_registers: &Cx4Registers, risc_registers: &mut RiscRegisters, opcode: u16) {
+    log::trace!("smul ${:02X}", opcode & 0xFF);
+    let value = read_register(cx4_registers, risc_registers, opcode);
+    smul(risc_registers, value);
+}
+
+fn smul_imm(registers: &mut RiscRegisters, opcode: u16) {
+    log::trace!("smul #${:02X}", opcode & 0xFF);
+    let value = (opcode & 0xFF).into();
+    smul(registers, value);
+}
+
+fn smul(registers: &mut RiscRegisters, value: u32) {
+    let a = ((registers.a as i32) << 8) >> 8;
+    let b = ((value as i32) << 8) >> 8;
+    registers.m = i64::from(a) * i64::from(b);
+}
+
+fn and_a_op(cx4_registers: &Cx4Registers, risc_registers: &mut RiscRegisters, opcode: u16) {
+    log::trace!("and A, ${:02X}", opcode & 0xFF);
+    let value = read_register(cx4_registers, risc_registers, opcode);
+    and(risc_registers, opcode, value);
+}
+
+fn and_a_imm(registers: &mut RiscRegisters, opcode: u16) {
+    log::trace!("and A, #${:02X}", opcode & 0xFF);
+    and(registers, opcode, (opcode & 0xFF).into());
+}
+
+fn and(registers: &mut RiscRegisters, opcode: u16, value: u32) {
+    let result = apply_a_shift(registers.a, opcode) & value;
+    registers.set_nz(result);
+
+    registers.a = result & 0xFFFFFF;
+}
+
+fn or_a_op(cx4_registers: &Cx4Registers, risc_registers: &mut RiscRegisters, opcode: u16) {
+    log::trace!("or A, ${:02X}", opcode & 0xFF);
+    let value = read_register(cx4_registers, risc_registers, opcode);
+    or(risc_registers, opcode, value);
+}
+
+fn or_a_imm(registers: &mut RiscRegisters, opcode: u16) {
+    log::trace!("or A, #${:02X}", opcode & 0xFF);
+    or(registers, opcode, (opcode & 0xFF).into());
+}
+
+fn or(registers: &mut RiscRegisters, opcode: u16, value: u32) {
+    let result = apply_a_shift(registers.a, opcode) | value;
+    registers.set_nz(result);
+
+    registers.a = result & 0xFFFFFF;
+}
+
+fn xor_a_op(cx4_registers: &Cx4Registers, risc_registers: &mut RiscRegisters, opcode: u16) {
+    log::trace!("xor A, ${:02X}", opcode & 0xFF);
+    let value = read_register(cx4_registers, risc_registers, opcode);
+    xor(risc_registers, opcode, value);
+}
+
+fn xor_a_imm(risc_registers: &mut RiscRegisters, opcode: u16) {
+    log::trace!("xor A, #${:02X}", opcode & 0xFF);
+    xor(risc_registers, opcode, (opcode & 0xFF).into());
+}
+
+fn xor(registers: &mut RiscRegisters, opcode: u16, value: u32) {
+    let result = apply_a_shift(registers.a, opcode) ^ value;
+    registers.set_nz(result);
+
+    registers.a = result & 0xFFFFFF;
+}
+
+fn shr_a_op(cx4_registers: &Cx4Registers, risc_registers: &mut RiscRegisters, opcode: u16) {
+    log::trace!("shr ${:02X}", opcode & 0xFF);
+    let value = read_register(cx4_registers, risc_registers, opcode);
+    shr(risc_registers, value);
+}
+
+fn shr_a_imm(registers: &mut RiscRegisters, opcode: u16) {
+    log::trace!("shr #${:02X}", opcode & 0xFF);
+    shr(registers, (opcode & 0x1F).into());
+}
+
+fn shr(registers: &mut RiscRegisters, value: u32) {
+    if value <= 24 {
+        registers.a >>= value;
+    }
+    registers.set_nz(registers.a);
+}
+
+fn sar_a_op(cx4_registers: &Cx4Registers, risc_registers: &mut RiscRegisters, opcode: u16) {
+    log::trace!("sar ${:02X}", opcode & 0xFF);
+    let value = read_register(cx4_registers, risc_registers, opcode);
+    sar(risc_registers, value);
+}
+
+fn sar_a_imm(registers: &mut RiscRegisters, opcode: u16) {
+    log::trace!("sar #${:02X}", opcode & 0xFF);
+    sar(registers, (opcode & 0x1F).into());
+}
+
+fn sar(registers: &mut RiscRegisters, value: u32) {
+    if value <= 24 {
+        registers.a = ((((registers.a as i32) << 8) >> (8 + value)) as u32) & 0xFFFFFF;
+    }
+    registers.set_nz(registers.a);
+}
+
+fn shl_a_op(cx4_registers: &Cx4Registers, risc_registers: &mut RiscRegisters, opcode: u16) {
+    log::trace!("shl ${:02X}", opcode & 0xFF);
+    let value = read_register(cx4_registers, risc_registers, opcode);
+    shl(risc_registers, value);
+}
+
+fn shl_a_imm(registers: &mut RiscRegisters, opcode: u16) {
+    log::trace!("shl #${:02X}", opcode & 0xFF);
+    shl(registers, (opcode & 0x1F).into());
+}
+
+fn shl(registers: &mut RiscRegisters, value: u32) {
+    if value <= 24 {
+        registers.a = (registers.a << value) & 0xFFFFFF;
+    }
+    registers.set_nz(registers.a);
+}
+
+fn ror_a_op(cx4_registers: &Cx4Registers, risc_registers: &mut RiscRegisters, opcode: u16) {
+    log::trace!("ror ${:02X}", opcode & 0xFF);
+    let value = read_register(cx4_registers, risc_registers, opcode);
+    ror(risc_registers, value);
+}
+
+fn ror_a_imm(registers: &mut RiscRegisters, opcode: u16) {
+    log::trace!("ror #${:02X}", opcode & 0xFF);
+    ror(registers, (opcode & 0x1F).into());
+}
+
+fn ror(registers: &mut RiscRegisters, value: u32) {
+    if value <= 24 {
+        registers.a = ((registers.a >> value) | (registers.a << (24 - value))) & 0xFFFFFF;
+    }
+    registers.set_nz(registers.a);
+}
+
+fn sign_extend(registers: &mut RiscRegisters, opcode: u16) {
+    log::trace!("exts, opcode={opcode:04X}");
+    match opcode & 0x0300 {
+        0x0100 => {
+            registers.a = ((registers.a as i8) as u32) & 0xFFFFFF;
+        }
+        0x0200 => {
+            registers.a = ((registers.a as i16) as u32) & 0xFFFFFF;
+        }
+        _ => {
+            log::warn!("Unexpected sign extension opcode: {opcode:04X}");
+        }
+    }
+    registers.set_nz(registers.a);
+}
+
+fn inc_snes_ptr(registers: &mut RiscRegisters) {
+    log::trace!("inc MAR");
+    registers.snes_pointer = (registers.snes_pointer + 1) & 0xFFFFFF;
+}
+
+fn apply_a_shift(a: u32, opcode: u16) -> u32 {
+    match opcode & 0x0300 {
+        0x0000 => a,
+        0x0100 => (a << 1) & 0xFFFFFF,
+        0x0200 => (a << 8) & 0xFFFFFF,
+        0x0300 => (a << 16) & 0xFFFFFF,
+        _ => unreachable!("value & 0x0300 is always one of the above values"),
+    }
+}
+
+fn read_register(cx4_registers: &Cx4Registers, risc_registers: &RiscRegisters, opcode: u16) -> u32 {
+    match opcode & 0xFF {
+        0x00 => risc_registers.a,
+        0x01 => ((risc_registers.m >> 24) as u32) & 0xFFFFFF,
+        0x02 => (risc_registers.m as u32) & 0xFFFFFF,
+        0x03 => risc_registers.snes_buffer.into(),
+        0x08 => risc_registers.rom_buffer,
+        0x0C => risc_registers.ram_buffer,
+        0x13 => risc_registers.snes_pointer,
+        0x1C => risc_registers.ram_pointer.into(),
+        0x20 => cx4_registers.instruction_pointer.into(),
+        0x28 => risc_registers.page.into(),
+        0x50 => 0x000000,
+        0x51 => 0xFFFFFF,
+        0x52 => 0x00FF00,
+        0x53 => 0xFF0000,
+        0x54 => 0x00FFFF,
+        0x55 => 0xFFFF00,
+        0x56 => 0x800000,
+        0x57 => 0x7FFFFF,
+        0x58 => 0x008000,
+        0x59 => 0x007FFF,
+        0x5A => 0xFF7FFF,
+        0x5B => 0xFFFF7F,
+        0x5C => 0x010000,
+        0x5D => 0xFEFFFF,
+        0x5E => 0x000100,
+        0x5F => 0x00FEFF,
+        0x60..=0x6F => {
+            let register_idx = (opcode & 0xF) as usize;
+            cx4_registers.gpr[register_idx]
+        }
+        _ => {
+            log::warn!("Unhandled CX4 coprocessor register read: {:02X}", opcode & 0xFF);
+            0x00
+        }
+    }
+}
+
+fn write_register(
+    cx4_registers: &mut Cx4Registers,
+    risc_registers: &mut RiscRegisters,
+    opcode: u16,
+    value: u32,
+) {
+    match opcode & 0xFF {
+        0x00 => {
+            risc_registers.a = value;
+        }
+        0x03 => {
+            risc_registers.snes_buffer = value as u8;
+        }
+        0x0C => {
+            risc_registers.ram_buffer = value & 0xFFFFFF;
+        }
+        0x13 => {
+            risc_registers.snes_pointer = value & 0xFFFFFF;
+        }
+        0x1C => {
+            risc_registers.ram_pointer = (value & 0xFFF) as u16;
+        }
+        0x20 => {
+            cx4_registers.instruction_pointer = value as u8;
+        }
+        0x28 => {
+            risc_registers.page = value as u16;
+        }
+        0x60..=0x6F => {
+            let register_idx = (opcode & 0xF) as usize;
+            cx4_registers.gpr[register_idx] = value & 0xFFFFFF;
+        }
+        _ => {
+            log::warn!("Unhandled CX4 coprocessor register write: {:02X}", opcode & 0xFF);
+        }
+    }
+}

--- a/snes-core/src/memory/cartridge/cx4/functions/rom.rs
+++ b/snes-core/src/memory/cartridge/cx4/functions/rom.rs
@@ -1,0 +1,134 @@
+#![allow(clippy::needless_range_loop)]
+
+use std::sync::OnceLock;
+
+const PI: f64 = std::f64::consts::PI;
+
+type Cx4Rom = [u32; 1024];
+
+pub(super) fn read(address: u32) -> u32 {
+    static ROM: OnceLock<Box<Cx4Rom>> = OnceLock::new();
+
+    let rom = ROM.get_or_init(|| {
+        let mut rom: Box<Cx4Rom> = vec![0; 1024].into_boxed_slice().try_into().unwrap();
+
+        populate_div(&mut rom);
+        populate_sqrt(&mut rom);
+        populate_sin(&mut rom);
+        populate_asin(&mut rom);
+        populate_tan(&mut rom);
+        populate_cos(&mut rom);
+
+        rom
+    });
+    rom[(address & 0x3FF) as usize]
+}
+
+fn populate_div(rom: &mut Cx4Rom) {
+    // Division by 0 produces $FFFFFF (overflow)
+    rom[0] = 0xFFFFFF;
+
+    for i in 0x001..0x100 {
+        rom[i as usize] = 0x800000 / i;
+    }
+}
+
+fn populate_sqrt(rom: &mut Cx4Rom) {
+    for i in 0x100..0x200 {
+        let input = i - 0x100;
+        let scaled_sqrt = f64::from(0x100000) * (input as f64).sqrt();
+        rom[i] = (scaled_sqrt as u32) & 0xFFFFFF;
+    }
+}
+
+fn populate_sin(rom: &mut Cx4Rom) {
+    for i in 0x200..0x280 {
+        let input = i - 0x200;
+        let scaled_sin = f64::from(0x1000000) * (input as f64 / 256.0 * PI).sin();
+        rom[i] = (scaled_sin as u32) & 0xFFFFFF;
+    }
+}
+
+fn populate_asin(rom: &mut Cx4Rom) {
+    for i in 0x280..0x300 {
+        let input = i - 0x280;
+        let scaled_asin = f64::from(0x800000) / (PI / 2.0) * (input as f64 / 128.0).asin();
+        rom[i] = (scaled_asin as u32) & 0xFFFFFF;
+    }
+}
+
+fn populate_tan(rom: &mut Cx4Rom) {
+    for i in 0x300..0x380 {
+        let input = i - 0x300;
+        let scaled_tan = f64::from(0x10000) * (input as f64 / 256.0 * PI).tan();
+        rom[i] = (scaled_tan as u32) & 0xFFFFFF;
+    }
+
+    // tan(pi / 4) is defined as 1; without this the value will be ~0.9999999
+    rom[0x340] = 0x010000;
+}
+
+fn populate_cos(rom: &mut Cx4Rom) {
+    // cos(0) produces $FFFFFF (overflow)
+    rom[0x380] = 0xFFFFFF;
+
+    for i in 0x381..0x400 {
+        let input = i - 0x380;
+        let scaled_cos = f64::from(0x1000000) * (input as f64 / 256.0 * PI).cos();
+        rom[i] = (scaled_cos as u32) & 0xFFFFFF;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn div() {
+        assert_eq!(read(0x000), 0xFFFFFF);
+        assert_eq!(read(0x0FF), 0x008080);
+    }
+
+    #[test]
+    fn sqrt() {
+        assert_eq!(read(0x100), 0x000000);
+        assert_eq!(read(0x1FF), 0xFF7FDF);
+    }
+
+    #[test]
+    fn sin() {
+        assert_eq!(read(0x200), 0x000000);
+        assert_eq!(read(0x27F), 0xFFFB10);
+    }
+
+    #[test]
+    fn asin() {
+        assert_eq!(read(0x280), 0x000000);
+        assert_eq!(read(0x2FF), 0x75CEB4);
+    }
+
+    #[test]
+    fn tan() {
+        assert_eq!(read(0x300), 0x000000);
+        assert_eq!(read(0x37F), 0x517BB5);
+    }
+
+    #[test]
+    fn cos() {
+        assert_eq!(read(0x380), 0xFFFFFF);
+        assert_eq!(read(0x3FF), 0x03243A);
+    }
+
+    #[test]
+    fn sum() {
+        let mut sum = 0;
+        for i in 0..0x400 {
+            let value = read(i);
+            sum += value & 0xFF;
+            sum += (value >> 8) & 0xFF;
+            sum += (value >> 16) & 0xFF;
+        }
+
+        assert_eq!(sum, 0x054336);
+    }
+}


### PR DESCRIPTION
The CX4 is a Capcom coprocessor used exclusively in _Mega Man X2_ and _Mega Man X3_. These two games use it for sprite transformations (e.g. scaling, rotation, and "disintegration"), rendering large composite sprites, rendering 3D wireframe models, and other geometric/trigonometric operations that benefit from being able to do really fast multiplication operations.

The chip itself is a Hitachi HG51B169 DSP clocked at around 20 MHz.

![Screenshot from 2023-11-11 02-30-06](https://github.com/jsgroth/jgenesis/assets/1137683/57e6cbf9-445e-40ef-81aa-a2651a149a29)

![Screenshot from 2023-11-11 02-35-25](https://github.com/jsgroth/jgenesis/assets/1137683/e6a8a275-42bc-413b-aaec-40727898fce4)
