### PR TITLE
Implement SNES DSP-1/2/3/4 and ST010/ST011 coprocessors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2996,6 +2996,7 @@ name = "snes-core"
 version = "0.5.1"
 dependencies = [
  "bincode",
+ "bytemuck",
  "crc",
  "jgenesis-common",
  "jgenesis-proc-macros",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2996,6 +2996,7 @@ name = "snes-core"
 version = "0.5.1"
 dependencies = [
  "bincode",
+ "crc",
  "jgenesis-common",
  "jgenesis-proc-macros",
  "log",

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,1 +1,1 @@
-doc-valid-idents = ["KHz", ".."]
+doc-valid-idents = ["KHz", "µPD77C25", "µPD96050", ".."]

--- a/jgenesis-cli/src/main.rs
+++ b/jgenesis-cli/src/main.rs
@@ -135,8 +135,12 @@ struct Args {
     snes_aspect_ratio: SnesAspectRatio,
 
     /// Disable hack that times SNES audio signal to 60Hz instead of ~60.098Hz
-    #[arg(long, default_value_t = true, action = clap::ArgAction::SetFalse, help_heading = SNES_OPTIONS_HEADING)]
+    #[arg(long = "no-snes-audio-60hz-hack", default_value_t = true, action = clap::ArgAction::SetFalse, help_heading = SNES_OPTIONS_HEADING)]
     snes_audio_60hz_hack: bool,
+
+    /// Specify SNES DSP-1 ROM path (required for DSP-1 games)
+    #[arg(long, help_heading = SNES_OPTIONS_HEADING)]
+    dsp1_rom_path: Option<String>,
 
     /// Window width in pixels; height must also be set
     #[arg(long, help_heading = VIDEO_OPTIONS_HEADING)]
@@ -555,6 +559,7 @@ fn run_snes(args: Args) -> anyhow::Result<()> {
         forced_timing_mode: args.snes_timing_mode,
         aspect_ratio: args.snes_aspect_ratio,
         audio_60hz_hack: args.snes_audio_60hz_hack,
+        dsp1_rom_path: args.dsp1_rom_path,
     };
 
     let mut emulator = jgenesis_native_driver::create_snes(config.into())?;

--- a/jgenesis-cli/src/main.rs
+++ b/jgenesis-cli/src/main.rs
@@ -154,6 +154,14 @@ struct Args {
     #[arg(long, help_heading = SNES_OPTIONS_HEADING)]
     dsp4_rom_path: Option<String>,
 
+    /// Specify SNES ST010 ROM path (required for ST010 games)
+    #[arg(long, help_heading = SNES_OPTIONS_HEADING)]
+    st010_rom_path: Option<String>,
+
+    /// Specify SNES ST011 ROM path (required for ST011 games)
+    #[arg(long, help_heading = SNES_OPTIONS_HEADING)]
+    st011_rom_path: Option<String>,
+
     /// Window width in pixels; height must also be set
     #[arg(long, help_heading = VIDEO_OPTIONS_HEADING)]
     window_width: Option<u32>,
@@ -575,6 +583,8 @@ fn run_snes(args: Args) -> anyhow::Result<()> {
         dsp2_rom_path: args.dsp2_rom_path,
         dsp3_rom_path: args.dsp3_rom_path,
         dsp4_rom_path: args.dsp4_rom_path,
+        st010_rom_path: args.st010_rom_path,
+        st011_rom_path: args.st011_rom_path,
     };
 
     let mut emulator = jgenesis_native_driver::create_snes(config.into())?;

--- a/jgenesis-cli/src/main.rs
+++ b/jgenesis-cli/src/main.rs
@@ -142,6 +142,18 @@ struct Args {
     #[arg(long, help_heading = SNES_OPTIONS_HEADING)]
     dsp1_rom_path: Option<String>,
 
+    /// Specify SNES DSP-2 ROM path (required for DSP-2 games)
+    #[arg(long, help_heading = SNES_OPTIONS_HEADING)]
+    dsp2_rom_path: Option<String>,
+
+    /// Specify SNES DSP-3 ROM path (required for DSP-3 games)
+    #[arg(long, help_heading = SNES_OPTIONS_HEADING)]
+    dsp3_rom_path: Option<String>,
+
+    /// Specify SNES DSP-4 ROM path (required for DSP-4 games)
+    #[arg(long, help_heading = SNES_OPTIONS_HEADING)]
+    dsp4_rom_path: Option<String>,
+
     /// Window width in pixels; height must also be set
     #[arg(long, help_heading = VIDEO_OPTIONS_HEADING)]
     window_width: Option<u32>,
@@ -560,6 +572,9 @@ fn run_snes(args: Args) -> anyhow::Result<()> {
         aspect_ratio: args.snes_aspect_ratio,
         audio_60hz_hack: args.snes_audio_60hz_hack,
         dsp1_rom_path: args.dsp1_rom_path,
+        dsp2_rom_path: args.dsp2_rom_path,
+        dsp3_rom_path: args.dsp3_rom_path,
+        dsp4_rom_path: args.dsp4_rom_path,
     };
 
     let mut emulator = jgenesis_native_driver::create_snes(config.into())?;

--- a/jgenesis-gui/src/app.rs
+++ b/jgenesis-gui/src/app.rs
@@ -199,6 +199,8 @@ struct SnesAppConfig {
     dsp2_rom_path: Option<String>,
     dsp3_rom_path: Option<String>,
     dsp4_rom_path: Option<String>,
+    st010_rom_path: Option<String>,
+    st011_rom_path: Option<String>,
 }
 
 impl Default for SnesAppConfig {
@@ -342,6 +344,8 @@ impl AppConfig {
             dsp2_rom_path: self.snes.dsp2_rom_path.clone(),
             dsp3_rom_path: self.snes.dsp3_rom_path.clone(),
             dsp4_rom_path: self.snes.dsp4_rom_path.clone(),
+            st010_rom_path: self.snes.st010_rom_path.clone(),
+            st011_rom_path: self.snes.st011_rom_path.clone(),
         })
     }
 }
@@ -705,6 +709,24 @@ impl App {
                 }
 
                 ui.label("DSP-4 ROM path");
+            });
+
+            ui.horizontal(|ui| {
+                let st010_rom_path = self.config.snes.st010_rom_path.as_deref();
+                if ui.button(st010_rom_path.unwrap_or("<None>")).clicked() {
+                    Self::pick_coprocessor_rom_path(&mut self.config.snes.st010_rom_path);
+                }
+
+                ui.label("ST010 ROM path");
+            });
+
+            ui.horizontal(|ui| {
+                let st011_rom_path = self.config.snes.st011_rom_path.as_deref();
+                if ui.button(st011_rom_path.unwrap_or("<None>")).clicked() {
+                    Self::pick_coprocessor_rom_path(&mut self.config.snes.st011_rom_path);
+                }
+
+                ui.label("ST011 ROM path");
             });
         });
         if !open {

--- a/jgenesis-gui/src/app.rs
+++ b/jgenesis-gui/src/app.rs
@@ -195,6 +195,7 @@ struct SnesAppConfig {
     aspect_ratio: SnesAspectRatio,
     #[serde(default = "true_fn")]
     audio_60hz_hack: bool,
+    dsp1_rom_path: Option<String>,
 }
 
 impl Default for SnesAppConfig {
@@ -334,6 +335,7 @@ impl AppConfig {
             forced_timing_mode: self.snes.forced_timing_mode,
             aspect_ratio: self.snes.aspect_ratio,
             audio_60hz_hack: self.snes.audio_60hz_hack,
+            dsp1_rom_path: self.snes.dsp1_rom_path.clone(),
         })
     }
 }
@@ -661,6 +663,25 @@ impl App {
                         "PAL",
                     );
                 });
+            });
+
+            ui.horizontal(|ui| {
+                let dsp1_rom_path = self.config.snes.dsp1_rom_path.as_deref();
+                if ui.button(dsp1_rom_path.unwrap_or("<None>")).clicked() {
+                    if let Some(path) = FileDialog::new().pick_file() {
+                        match path.to_str() {
+                            Some(path) => self.config.snes.dsp1_rom_path = Some(path.into()),
+                            None => {
+                                log::error!(
+                                    "Unable to convert path to string: '{}'",
+                                    path.display()
+                                );
+                            }
+                        }
+                    }
+                }
+
+                ui.label("DSP-1 ROM path");
             });
         });
         if !open {

--- a/jgenesis-gui/src/app.rs
+++ b/jgenesis-gui/src/app.rs
@@ -196,6 +196,9 @@ struct SnesAppConfig {
     #[serde(default = "true_fn")]
     audio_60hz_hack: bool,
     dsp1_rom_path: Option<String>,
+    dsp2_rom_path: Option<String>,
+    dsp3_rom_path: Option<String>,
+    dsp4_rom_path: Option<String>,
 }
 
 impl Default for SnesAppConfig {
@@ -336,6 +339,9 @@ impl AppConfig {
             aspect_ratio: self.snes.aspect_ratio,
             audio_60hz_hack: self.snes.audio_60hz_hack,
             dsp1_rom_path: self.snes.dsp1_rom_path.clone(),
+            dsp2_rom_path: self.snes.dsp2_rom_path.clone(),
+            dsp3_rom_path: self.snes.dsp3_rom_path.clone(),
+            dsp4_rom_path: self.snes.dsp4_rom_path.clone(),
         })
     }
 }
@@ -668,24 +674,54 @@ impl App {
             ui.horizontal(|ui| {
                 let dsp1_rom_path = self.config.snes.dsp1_rom_path.as_deref();
                 if ui.button(dsp1_rom_path.unwrap_or("<None>")).clicked() {
-                    if let Some(path) = FileDialog::new().pick_file() {
-                        match path.to_str() {
-                            Some(path) => self.config.snes.dsp1_rom_path = Some(path.into()),
-                            None => {
-                                log::error!(
-                                    "Unable to convert path to string: '{}'",
-                                    path.display()
-                                );
-                            }
-                        }
-                    }
+                    Self::pick_coprocessor_rom_path(&mut self.config.snes.dsp1_rom_path);
                 }
 
                 ui.label("DSP-1 ROM path");
             });
+
+            ui.horizontal(|ui| {
+                let dsp2_rom_path = self.config.snes.dsp2_rom_path.as_deref();
+                if ui.button(dsp2_rom_path.unwrap_or("<None>")).clicked() {
+                    Self::pick_coprocessor_rom_path(&mut self.config.snes.dsp2_rom_path);
+                }
+
+                ui.label("DSP-2 ROM path");
+            });
+
+            ui.horizontal(|ui| {
+                let dsp3_rom_path = self.config.snes.dsp3_rom_path.as_deref();
+                if ui.button(dsp3_rom_path.unwrap_or("<None>")).clicked() {
+                    Self::pick_coprocessor_rom_path(&mut self.config.snes.dsp3_rom_path);
+                }
+
+                ui.label("DSP-3 ROM path");
+            });
+
+            ui.horizontal(|ui| {
+                let dsp4_rom_path = self.config.snes.dsp4_rom_path.as_deref();
+                if ui.button(dsp4_rom_path.unwrap_or("<None>")).clicked() {
+                    Self::pick_coprocessor_rom_path(&mut self.config.snes.dsp4_rom_path);
+                }
+
+                ui.label("DSP-4 ROM path");
+            });
         });
         if !open {
             self.state.open_windows.remove(&OpenWindow::SnesGeneral);
+        }
+    }
+
+    fn pick_coprocessor_rom_path(out_path: &mut Option<String>) {
+        let Some(path) = FileDialog::new().pick_file() else { return };
+
+        match path.to_str() {
+            Some(path) => {
+                *out_path = Some(path.into());
+            }
+            None => {
+                log::error!("Unable to convert path to string: '{}'", path.display());
+            }
         }
     }
 

--- a/jgenesis-native-driver/src/config.rs
+++ b/jgenesis-native-driver/src/config.rs
@@ -14,7 +14,8 @@ use segacd_core::api::SegaCdEmulatorConfig;
 use serde::{Deserialize, Serialize};
 use smsgg_core::psg::PsgVersion;
 use smsgg_core::{SmsGgEmulatorConfig, SmsRegion, VdpVersion};
-use snes_core::api::{SnesAspectRatio, SnesEmulatorConfig};
+use snes_core::api::{CoprocessorRoms, SnesAspectRatio, SnesEmulatorConfig};
+use std::{fs, io};
 
 pub(crate) const DEFAULT_GENESIS_WINDOW_SIZE: WindowSize = WindowSize { width: 878, height: 672 };
 
@@ -223,6 +224,7 @@ pub struct SnesConfig {
     pub forced_timing_mode: Option<TimingMode>,
     pub aspect_ratio: SnesAspectRatio,
     pub audio_60hz_hack: bool,
+    pub dsp1_rom_path: Option<String>,
 }
 
 impl SnesConfig {
@@ -232,5 +234,14 @@ impl SnesConfig {
             aspect_ratio: self.aspect_ratio,
             audio_60hz_hack: self.audio_60hz_hack,
         }
+    }
+
+    pub(crate) fn to_coprocessor_roms(&self) -> Result<CoprocessorRoms, (io::Error, String)> {
+        let dsp1 = match &self.dsp1_rom_path {
+            Some(path) => Some(fs::read(path).map_err(|err| (err, path.clone()))?),
+            None => None,
+        };
+
+        Ok(CoprocessorRoms { dsp1 })
     }
 }

--- a/jgenesis-native-driver/src/config.rs
+++ b/jgenesis-native-driver/src/config.rs
@@ -225,6 +225,9 @@ pub struct SnesConfig {
     pub aspect_ratio: SnesAspectRatio,
     pub audio_60hz_hack: bool,
     pub dsp1_rom_path: Option<String>,
+    pub dsp2_rom_path: Option<String>,
+    pub dsp3_rom_path: Option<String>,
+    pub dsp4_rom_path: Option<String>,
 }
 
 impl SnesConfig {
@@ -237,11 +240,20 @@ impl SnesConfig {
     }
 
     pub(crate) fn to_coprocessor_roms(&self) -> Result<CoprocessorRoms, (io::Error, String)> {
-        let dsp1 = match &self.dsp1_rom_path {
-            Some(path) => Some(fs::read(path).map_err(|err| (err, path.clone()))?),
-            None => None,
-        };
+        let dsp1 = read_coprocessor_rom(self.dsp1_rom_path.as_ref())?;
+        let dsp2 = read_coprocessor_rom(self.dsp2_rom_path.as_ref())?;
+        let dsp3 = read_coprocessor_rom(self.dsp3_rom_path.as_ref())?;
+        let dsp4 = read_coprocessor_rom(self.dsp4_rom_path.as_ref())?;
 
-        Ok(CoprocessorRoms { dsp1 })
+        Ok(CoprocessorRoms { dsp1, dsp2, dsp3, dsp4 })
     }
+}
+
+fn read_coprocessor_rom(path: Option<&String>) -> Result<Option<Vec<u8>>, (io::Error, String)> {
+    let rom = match path {
+        Some(path) => Some(fs::read(path).map_err(|err| (err, path.clone()))?),
+        None => None,
+    };
+
+    Ok(rom)
 }

--- a/jgenesis-native-driver/src/config.rs
+++ b/jgenesis-native-driver/src/config.rs
@@ -228,6 +228,8 @@ pub struct SnesConfig {
     pub dsp2_rom_path: Option<String>,
     pub dsp3_rom_path: Option<String>,
     pub dsp4_rom_path: Option<String>,
+    pub st010_rom_path: Option<String>,
+    pub st011_rom_path: Option<String>,
 }
 
 impl SnesConfig {
@@ -244,8 +246,10 @@ impl SnesConfig {
         let dsp2 = self.dsp2_rom_path.clone().map(coprocessor_read_fn);
         let dsp3 = self.dsp3_rom_path.clone().map(coprocessor_read_fn);
         let dsp4 = self.dsp4_rom_path.clone().map(coprocessor_read_fn);
+        let st010 = self.st010_rom_path.clone().map(coprocessor_read_fn);
+        let st011 = self.st011_rom_path.clone().map(coprocessor_read_fn);
 
-        CoprocessorRoms { dsp1, dsp2, dsp3, dsp4 }
+        CoprocessorRoms { dsp1, dsp2, dsp3, dsp4, st010, st011 }
     }
 }
 

--- a/jgenesis-native-driver/src/mainloop.rs
+++ b/jgenesis-native-driver/src/mainloop.rs
@@ -523,12 +523,6 @@ pub enum NativeEmulatorError {
     SegaCdDisc(#[from] DiscError),
     #[error("{0}")]
     SnesLoad(#[from] LoadError),
-    #[error("Error loading SNES coprocessor ROM file at '{path}': {source}")]
-    SnesCoprocessorRomOpen {
-        #[source]
-        source: io::Error,
-        path: String,
-    },
     #[error("I/O error opening save state file '{path}': {source}")]
     StateFileOpen {
         path: String,
@@ -923,9 +917,7 @@ pub fn create_snes(config: Box<SnesConfig>) -> NativeEmulatorResult<NativeSnesEm
     }
 
     let emulator_config = config.to_emulator_config();
-    let coprocessor_roms = config
-        .to_coprocessor_roms()
-        .map_err(|(source, path)| NativeEmulatorError::SnesCoprocessorRomOpen { source, path })?;
+    let coprocessor_roms = config.to_coprocessor_roms();
     let mut emulator = SnesEmulator::create(rom, initial_sram, emulator_config, coprocessor_roms)?;
 
     let (video, audio, joystick, event_pump) = init_sdl()?;

--- a/jgenesis-web/src/lib.rs
+++ b/jgenesis-web/src/lib.rs
@@ -474,7 +474,7 @@ fn open_emulator(rom: Vec<u8>, file_name: &str, config_ref: &WebConfigRef) -> Em
                 rom,
                 None,
                 config_ref.borrow().snes.to_emulator_config(),
-                CoprocessorProgramRoms { dsp1: None },
+                CoprocessorProgramRoms { dsp1: None, dsp2: None, dsp3: None, dsp4: None },
             )
             .expect("Unable to create SNES emulator");
             Emulator::Snes(emulator, SnesInputs::default())

--- a/jgenesis-web/src/lib.rs
+++ b/jgenesis-web/src/lib.rs
@@ -474,7 +474,14 @@ fn open_emulator(rom: Vec<u8>, file_name: &str, config_ref: &WebConfigRef) -> Em
                 rom,
                 None,
                 config_ref.borrow().snes.to_emulator_config(),
-                CoprocessorRoms { dsp1: None, dsp2: None, dsp3: None, dsp4: None },
+                CoprocessorRoms {
+                    dsp1: None,
+                    dsp2: None,
+                    dsp3: None,
+                    dsp4: None,
+                    st010: None,
+                    st011: None,
+                },
             )
             .expect("Unable to create SNES emulator");
             Emulator::Snes(emulator, SnesInputs::default())

--- a/jgenesis-web/src/lib.rs
+++ b/jgenesis-web/src/lib.rs
@@ -15,7 +15,7 @@ use jgenesis_renderer::renderer::WgpuRenderer;
 use js_sys::Promise;
 use rfd::AsyncFileDialog;
 use smsgg_core::{SmsGgEmulator, SmsGgInputs};
-use snes_core::api::{CoprocessorProgramRoms, SnesEmulator};
+use snes_core::api::{CoprocessorRoms, SnesEmulator};
 use snes_core::input::SnesInputs;
 use std::fmt::{Debug, Display, Formatter};
 use std::path::Path;
@@ -474,7 +474,7 @@ fn open_emulator(rom: Vec<u8>, file_name: &str, config_ref: &WebConfigRef) -> Em
                 rom,
                 None,
                 config_ref.borrow().snes.to_emulator_config(),
-                CoprocessorProgramRoms { dsp1: None, dsp2: None, dsp3: None, dsp4: None },
+                CoprocessorRoms { dsp1: None, dsp2: None, dsp3: None, dsp4: None },
             )
             .expect("Unable to create SNES emulator");
             Emulator::Snes(emulator, SnesInputs::default())

--- a/jgenesis-web/src/lib.rs
+++ b/jgenesis-web/src/lib.rs
@@ -15,7 +15,7 @@ use jgenesis_renderer::renderer::WgpuRenderer;
 use js_sys::Promise;
 use rfd::AsyncFileDialog;
 use smsgg_core::{SmsGgEmulator, SmsGgInputs};
-use snes_core::api::SnesEmulator;
+use snes_core::api::{CoprocessorProgramRoms, SnesEmulator};
 use snes_core::input::SnesInputs;
 use std::fmt::{Debug, Display, Formatter};
 use std::path::Path;
@@ -470,8 +470,13 @@ fn open_emulator(rom: Vec<u8>, file_name: &str, config_ref: &WebConfigRef) -> Em
         "sfc" => {
             js::showSnesConfig();
 
-            let emulator =
-                SnesEmulator::create(rom, None, config_ref.borrow().snes.to_emulator_config());
+            let emulator = SnesEmulator::create(
+                rom,
+                None,
+                config_ref.borrow().snes.to_emulator_config(),
+                CoprocessorProgramRoms { dsp1: None },
+            )
+            .expect("Unable to create SNES emulator");
             Emulator::Snes(emulator, SnesInputs::default())
         }
         _ => panic!("Unsupported extension: {file_ext}"),

--- a/snes-core/Cargo.toml
+++ b/snes-core/Cargo.toml
@@ -16,6 +16,7 @@ spc700-emu = { path = "../spc700-emu" }
 wdc65816-emu = { path = "../wdc65816-emu" }
 
 bincode = { workspace = true }
+bytemuck = { workspace = true }
 crc = { workspace = true }
 log = { workspace = true }
 serde = { workspace = true, optional = true }

--- a/snes-core/Cargo.toml
+++ b/snes-core/Cargo.toml
@@ -16,6 +16,7 @@ spc700-emu = { path = "../spc700-emu" }
 wdc65816-emu = { path = "../wdc65816-emu" }
 
 bincode = { workspace = true }
+crc = { workspace = true }
 log = { workspace = true }
 serde = { workspace = true, optional = true }
 thiserror = { workspace = true }

--- a/snes-core/src/api.rs
+++ b/snes-core/src/api.rs
@@ -60,6 +60,9 @@ pub struct SnesEmulatorConfig {
 #[derive(Debug, Clone, Encode, Decode)]
 pub struct CoprocessorRoms {
     pub dsp1: Option<Vec<u8>>,
+    pub dsp2: Option<Vec<u8>>,
+    pub dsp3: Option<Vec<u8>>,
+    pub dsp4: Option<Vec<u8>>,
 }
 
 #[derive(Debug, Error)]
@@ -74,8 +77,14 @@ pub enum SnesError<RErr, AErr, SErr> {
 
 #[derive(Debug, Error)]
 pub enum LoadError {
-    #[error("Cannot load DSP-1 cartridge because DSP-1 program ROM is not configured")]
+    #[error("Cannot load DSP-1 cartridge because DSP-1 ROM is not configured")]
     MissingDsp1Rom,
+    #[error("Cannot load DSP-2 cartridge because DSP-2 ROM is not configured")]
+    MissingDsp2Rom,
+    #[error("Cannot load DSP-3 cartridge because DSP-3 ROM is not configured")]
+    MissingDsp3Rom,
+    #[error("Cannot load DSP-4 cartridge because DSP-4 ROM is not configured")]
+    MissingDsp4Rom,
 }
 
 pub type LoadResult<T> = Result<T, LoadError>;

--- a/snes-core/src/api.rs
+++ b/snes-core/src/api.rs
@@ -65,6 +65,8 @@ pub struct CoprocessorRoms {
     pub dsp2: Option<Box<CoprocessorRomFn>>,
     pub dsp3: Option<Box<CoprocessorRomFn>>,
     pub dsp4: Option<Box<CoprocessorRomFn>>,
+    pub st010: Option<Box<CoprocessorRomFn>>,
+    pub st011: Option<Box<CoprocessorRomFn>>,
 }
 
 #[derive(Debug, Error)]
@@ -87,6 +89,10 @@ pub enum LoadError {
     MissingDsp3Rom,
     #[error("Cannot load DSP-4 cartridge because DSP-4 ROM is not configured")]
     MissingDsp4Rom,
+    #[error("Cannot load ST010 cartridge because ST010 ROM is not configured")]
+    MissingSt010Rom,
+    #[error("Cannot load ST011 cartridge because ST011 ROM is not configured")]
+    MissingSt011Rom,
     #[error("Failed to load required coprocessor ROM from '{path}': {source}")]
     CoprocessorRomLoad {
         #[source]
@@ -141,7 +147,8 @@ impl SnesEmulator {
         let main_cpu = Wdc65816::new();
         let cpu_registers = CpuInternalRegisters::new();
         let dma_unit = DmaUnit::new();
-        let mut memory = Memory::create(rom, initial_sram, &coprocessor_roms)?;
+        let mut memory =
+            Memory::create(rom, initial_sram, &coprocessor_roms, config.forced_timing_mode)?;
 
         let timing_mode =
             config.forced_timing_mode.unwrap_or_else(|| memory.cartridge_timing_mode());

--- a/snes-core/src/apu.rs
+++ b/snes-core/src/apu.rs
@@ -4,6 +4,7 @@ mod timer;
 
 use crate::apu::dsp::AudioDsp;
 use crate::apu::timer::{FastTimer, SlowTimer};
+use crate::constants;
 use bincode::{Decode, Encode};
 use jgenesis_common::frontend::TimingMode;
 use jgenesis_common::num::GetBit;
@@ -11,10 +12,6 @@ use spc700_emu::traits::BusInterface;
 use spc700_emu::Spc700;
 
 const AUDIO_RAM_LEN: usize = 64 * 1024;
-
-// Main SNES master clock frequencies
-const NTSC_MASTER_CLOCK_FREQUENCY: u64 = 21_477_270;
-const PAL_MASTER_CLOCK_FREQUENCY: u64 = 21_281_370;
 
 const ACTUAL_APU_MASTER_CLOCK_FREQUENCY: u64 = 24_576_000;
 // APU master clock rate increased such that audio signal is timed to 60Hz for NTSC (and slightly under 50Hz for PAL)
@@ -228,8 +225,8 @@ macro_rules! new_spc700_bus {
 impl Apu {
     pub fn new(timing_mode: TimingMode, enable_audio_60hz_hack: bool) -> Self {
         let main_master_clock_frequency = match timing_mode {
-            TimingMode::Ntsc => NTSC_MASTER_CLOCK_FREQUENCY,
-            TimingMode::Pal => PAL_MASTER_CLOCK_FREQUENCY,
+            TimingMode::Ntsc => constants::NTSC_MASTER_CLOCK_FREQUENCY,
+            TimingMode::Pal => constants::PAL_MASTER_CLOCK_FREQUENCY,
         };
 
         let mut apu = Self {

--- a/snes-core/src/constants.rs
+++ b/snes-core/src/constants.rs
@@ -1,0 +1,3 @@
+// Main SNES master clock frequencies
+pub const NTSC_MASTER_CLOCK_FREQUENCY: u64 = 21_477_270;
+pub const PAL_MASTER_CLOCK_FREQUENCY: u64 = 21_281_370;

--- a/snes-core/src/coprocessors.rs
+++ b/snes-core/src/coprocessors.rs
@@ -1,1 +1,2 @@
 pub mod cx4;
+pub mod upd77c25;

--- a/snes-core/src/coprocessors/upd77c25.rs
+++ b/snes-core/src/coprocessors/upd77c25.rs
@@ -120,7 +120,7 @@ impl Registers {
             DataRegisterBits::Eight => {
                 self.sr.request_for_master = false;
 
-                (self.dr >> 8) as u8
+                self.dr as u8
             }
             DataRegisterBits::Sixteen => {
                 if self.sr.dr_busy {

--- a/snes-core/src/coprocessors/upd77c25.rs
+++ b/snes-core/src/coprocessors/upd77c25.rs
@@ -1,0 +1,326 @@
+//! NEC uPD77C25 CPU, used in the following SNES coprocessor chips:
+//!   * DSP-1 (19 games, including Super Mario Kart and Pilotwings)
+//!   * DSP-2 (1 game, Dungeon Master)
+//!   * DSP-3 (1 game, SD Gundam GX)
+//!   * DSP-4 (1 game, Top Gear 3000)
+//!   * ST010 (1 game, F1 ROC II: Race of Champions)
+//!   * ST011 (1 game, Hayazashi Nidan Morita Shogi)
+
+mod instructions;
+
+use bincode::{Decode, Encode};
+use jgenesis_common::num::GetBit;
+
+const DSP_PROGRAM_ROM_LEN_OPCODES: usize = 2048;
+const DSP_RAM_LEN_WORDS: usize = 256;
+
+#[derive(Debug, Clone, Copy, Default, Encode, Decode)]
+struct FlagsRegister {
+    z: bool,
+    c: bool,
+    s0: bool,
+    s1: bool,
+    ov0: bool,
+    ov1: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Encode, Decode)]
+enum DataRegisterBits {
+    Eight,
+    #[default]
+    Sixteen,
+}
+
+impl DataRegisterBits {
+    fn to_bit(self) -> bool {
+        self == Self::Eight
+    }
+
+    fn from_bit(bit: bool) -> Self {
+        if bit { Self::Eight } else { Self::Sixteen }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, Encode, Decode)]
+struct StatusRegister {
+    request_for_master: bool,
+    user_flag_0: bool,
+    user_flag_1: bool,
+    dr_busy: bool,
+    dr_control: DataRegisterBits,
+}
+
+impl StatusRegister {
+    fn write(&mut self, value: u16) {
+        self.user_flag_1 = value.bit(14);
+        self.user_flag_0 = value.bit(13);
+        self.dr_control = DataRegisterBits::from_bit(value.bit(10));
+        log::trace!("DR control set to {:?}", self.dr_control);
+    }
+}
+
+impl From<StatusRegister> for u8 {
+    fn from(value: StatusRegister) -> Self {
+        (u8::from(value.request_for_master) << 7)
+            | (u8::from(value.user_flag_1) << 6)
+            | (u8::from(value.user_flag_0) << 5)
+            | (u8::from(value.dr_busy) << 4)
+            | (u8::from(value.dr_control.to_bit()) << 2)
+    }
+}
+
+#[derive(Debug, Clone, Encode, Decode)]
+struct Registers {
+    dp: u16,
+    rp: u16,
+    pc: u16,
+    stack: [u16; 8],
+    stack_idx: u8,
+    stack_len: u8,
+    k: i16,
+    l: i16,
+    accumulator_a: i16,
+    accumulator_b: i16,
+    flags_a: FlagsRegister,
+    flags_b: FlagsRegister,
+    tr: i16,
+    trb: i16,
+    sr: StatusRegister,
+    dr: u16,
+}
+
+impl Registers {
+    fn new(variant: Upd77c25Variant) -> Self {
+        let stack_len = match variant {
+            Upd77c25Variant::Dsp => 4,
+        };
+
+        Self {
+            dp: 0,
+            rp: 0x3FF,
+            pc: 0,
+            stack: [0; 8],
+            stack_idx: 0,
+            stack_len,
+            k: 0,
+            l: 0,
+            accumulator_a: 0,
+            accumulator_b: 0,
+            flags_a: FlagsRegister::default(),
+            flags_b: FlagsRegister::default(),
+            tr: 0,
+            trb: 0,
+            sr: StatusRegister::default(),
+            dr: 0,
+        }
+    }
+
+    fn snes_read_data(&mut self) -> u8 {
+        match self.sr.dr_control {
+            DataRegisterBits::Eight => {
+                self.sr.request_for_master = false;
+
+                (self.dr >> 8) as u8
+            }
+            DataRegisterBits::Sixteen => {
+                if self.sr.dr_busy {
+                    self.sr.dr_busy = false;
+                    self.sr.request_for_master = false;
+
+                    (self.dr >> 8) as u8
+                } else {
+                    self.sr.dr_busy = true;
+
+                    self.dr as u8
+                }
+            }
+        }
+    }
+
+    fn snes_write_data(&mut self, value: u8) {
+        match self.sr.dr_control {
+            DataRegisterBits::Eight => {
+                self.sr.request_for_master = false;
+
+                self.dr = value.into();
+            }
+            DataRegisterBits::Sixteen => {
+                if self.sr.dr_busy {
+                    self.sr.dr_busy = false;
+                    self.sr.request_for_master = false;
+
+                    self.dr = (self.dr & 0x00FF) | (u16::from(value) << 8);
+                } else {
+                    self.sr.dr_busy = true;
+
+                    self.dr = (self.dr & 0xFF00) | u16::from(value);
+                }
+            }
+        }
+    }
+
+    fn upd_write_data(&mut self, value: u16) {
+        log::trace!("Wrote {value:04X} to DR");
+
+        self.dr = value;
+        self.sr.request_for_master = true;
+    }
+
+    fn reset(&mut self) {
+        self.pc = 0;
+        self.flags_a = FlagsRegister::default();
+        self.flags_b = FlagsRegister::default();
+        self.sr = StatusRegister::default();
+        self.rp = 0x3FF;
+    }
+
+    fn kl(&self) -> i32 {
+        i32::from(self.k) * i32::from(self.l)
+    }
+
+    fn push_stack(&mut self, pc: u16) {
+        self.stack[self.stack_idx as usize] = pc;
+        self.stack_idx = (self.stack_idx + 1) & (self.stack_len - 1);
+    }
+
+    fn pop_stack(&mut self) -> u16 {
+        log::trace!("Returning, current stack IDX is {}", self.stack_idx);
+
+        self.stack_idx = self.stack_idx.wrapping_sub(1) & (self.stack_len - 1);
+        self.stack[self.stack_idx as usize]
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Upd77c25Variant {
+    // DSP-1 / DSP-2 / DSP-3 / DSP-4
+    Dsp,
+}
+
+#[derive(Debug, Clone, Encode, Decode)]
+pub struct Upd77c25 {
+    program_rom: Box<[u32]>,
+    data_rom: Box<[u16]>,
+    ram: Box<[u16]>,
+    registers: Registers,
+    idling: bool,
+    master_cycles_elapsed: u64,
+}
+
+impl Upd77c25 {
+    pub fn new(rom: &[u8], variant: Upd77c25Variant) -> Self {
+        let (program_rom, data_rom) = convert_rom(rom);
+        // TODO ST010/ST011
+        let ram = vec![0; DSP_RAM_LEN_WORDS];
+
+        Self {
+            program_rom: program_rom.into_boxed_slice(),
+            data_rom: data_rom.into_boxed_slice(),
+            ram: ram.into_boxed_slice(),
+            registers: Registers::new(variant),
+            idling: false,
+            master_cycles_elapsed: 0,
+        }
+    }
+
+    pub fn read_data(&mut self) -> u8 {
+        let value = self.registers.snes_read_data();
+
+        if !self.registers.sr.request_for_master {
+            self.idling = false;
+        }
+
+        log::trace!("Data read: {value:02X}");
+
+        value
+    }
+
+    pub fn write_data(&mut self, value: u8) {
+        self.registers.snes_write_data(value);
+
+        log::trace!("Data write: {value:02X}");
+
+        if !self.registers.sr.request_for_master {
+            self.idling = false;
+        }
+    }
+
+    pub fn read_status(&self) -> u8 {
+        self.registers.sr.into()
+    }
+
+    pub fn tick(&mut self, master_cycles_elapsed: u64) {
+        self.master_cycles_elapsed += master_cycles_elapsed;
+
+        // TODO more accurate timing?
+        while self.master_cycles_elapsed >= 2 {
+            instructions::execute(self);
+            self.master_cycles_elapsed -= 2;
+        }
+    }
+
+    pub fn reset(&mut self) {
+        self.registers.reset();
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Endianness {
+    Little,
+    Big,
+}
+
+impl Endianness {
+    fn chunk_to_u16(self, chunk: &[u8]) -> u16 {
+        match self {
+            Self::Little => u16::from_le_bytes([chunk[0], chunk[1]]),
+            Self::Big => u16::from_be_bytes([chunk[0], chunk[1]]),
+        }
+    }
+
+    fn chunk_to_u32(self, chunk: &[u8]) -> u32 {
+        match self {
+            Self::Little => u32::from_le_bytes([chunk[0], chunk[1], chunk[2], 0]),
+            Self::Big => u32::from_be_bytes([0, chunk[0], chunk[1], chunk[2]]),
+        }
+    }
+}
+
+// Parse the ROM into program ROM and data ROM
+fn convert_rom(rom: &[u8]) -> (Vec<u32>, Vec<u16>) {
+    let endianness = detect_program_rom_endianness(rom);
+    log::info!("Detected ROM endian-ness: {endianness:?}");
+
+    // TODO ST010/ST011
+    let program_rom = convert_program_rom(&rom[..3 * DSP_PROGRAM_ROM_LEN_OPCODES], endianness);
+    let data_rom = convert_data_rom(&rom[3 * DSP_PROGRAM_ROM_LEN_OPCODES..], endianness);
+    (program_rom, data_rom)
+}
+
+// Convert program ROM from bytes to 24-bit opcodes
+fn convert_program_rom(program_rom: &[u8], endianness: Endianness) -> Vec<u32> {
+    program_rom.chunks_exact(3).map(|chunk| endianness.chunk_to_u32(chunk)).collect()
+}
+
+// Convert data ROM from bytes to 16-bit words
+fn convert_data_rom(data_rom: &[u8], endianness: Endianness) -> Vec<u16> {
+    data_rom.chunks_exact(2).map(|chunk| endianness.chunk_to_u16(chunk)).collect()
+}
+
+// All program ROMs used for this chip contain the opcode $97C00x in the first 4 opcodes, where
+// x is 4 times the opcode number
+fn detect_program_rom_endianness(program_rom: &[u8]) -> Endianness {
+    for (i, chunk) in program_rom.chunks_exact(3).enumerate().take(4) {
+        if chunk == [(i << 2) as u8, 0xC0, 0x97] {
+            return Endianness::Little;
+        }
+
+        if chunk == [0x97, 0xC0, (i << 2) as u8] {
+            return Endianness::Big;
+        }
+    }
+
+    log::warn!("Unable to detect uPD77C25 endian-ness; defaulting to little-endian");
+
+    Endianness::Little
+}

--- a/snes-core/src/coprocessors/upd77c25/instructions.rs
+++ b/snes-core/src/coprocessors/upd77c25/instructions.rs
@@ -1,0 +1,407 @@
+use crate::coprocessors::upd77c25::{FlagsRegister, Upd77c25};
+use jgenesis_common::num::{GetBit, SignBit};
+
+pub fn execute(cpu: &mut Upd77c25) {
+    if cpu.idling {
+        return;
+    }
+
+    let opcode = cpu.program_rom[cpu.registers.pc as usize];
+    log::trace!("Got opcode {opcode:06X} from PC {:03X}", cpu.registers.pc);
+    // TODO higher bit width for ST010/ST011
+    cpu.registers.pc = (cpu.registers.pc + 1) & 0x7FF;
+
+    match opcode & 0xC00000 {
+        0x000000 | 0x400000 => execute_alu(cpu, opcode),
+        0x800000 => execute_jump(cpu, opcode),
+        0xC00000 => execute_load(cpu, opcode),
+        _ => unreachable!("value & 0xC00000 is always one of the above values"),
+    }
+}
+
+fn execute_alu(cpu: &mut Upd77c25, opcode: u32) {
+    let alu_input = (opcode >> 20) & 0x3;
+    let alu_opcode = (opcode >> 16) & 0xF;
+
+    let source_register = (opcode >> 4) & 0xF;
+    let source = read_register(cpu, source_register);
+
+    let operand = match alu_input {
+        0x0 => cpu.ram[cpu.registers.dp as usize],
+        0x1 => source,
+        0x2 => ((2 * cpu.registers.kl()) >> 16) as u16,
+        0x3 => (2 * cpu.registers.kl()) as u16,
+        _ => unreachable!("value & 0x03 is always <= 0x03"),
+    };
+    let operand = operand as i16;
+
+    let (accumulator, flags, other_flags) = if opcode.bit(15) {
+        (&mut cpu.registers.accumulator_b, &mut cpu.registers.flags_b, cpu.registers.flags_a)
+    } else {
+        (&mut cpu.registers.accumulator_a, &mut cpu.registers.flags_a, cpu.registers.flags_b)
+    };
+
+    match alu_opcode {
+        0x00 => {}
+        0x01 => or(accumulator, operand, flags),
+        0x02 => and(accumulator, operand, flags),
+        0x03 => xor(accumulator, operand, flags),
+        0x04 => sub(accumulator, operand, false, flags),
+        0x05 => add(accumulator, operand, false, flags),
+        0x06 => sub(accumulator, operand, other_flags.c, flags),
+        0x07 => add(accumulator, operand, other_flags.c, flags),
+        0x08 => sub(accumulator, 1, false, flags),
+        0x09 => add(accumulator, 1, false, flags),
+        0x0A => not(accumulator, flags),
+        0x0B => sar1(accumulator, flags),
+        0x0C => rcl1(accumulator, other_flags.c, flags),
+        0x0D => sll2(accumulator, flags),
+        0x0E => sll4(accumulator, flags),
+        0x0F => xchg(accumulator, flags),
+        _ => unreachable!("value & 0x0F is always <= 0x0F"),
+    }
+
+    let dest_register = opcode & 0xF;
+    write_register(cpu, dest_register, source);
+
+    log::trace!("  Copied {source:04X} from {source_register:02X} to {dest_register:02X}");
+
+    let dpl_adjust = (opcode >> 13) & 0x3;
+    match dpl_adjust {
+        0x00 => {}
+        0x01 => {
+            cpu.registers.dp =
+                (cpu.registers.dp & !0x0F) | (cpu.registers.dp.wrapping_add(1) & 0x0F);
+        }
+        0x02 => {
+            cpu.registers.dp =
+                (cpu.registers.dp & !0x0F) | (cpu.registers.dp.wrapping_sub(1) & 0x0F);
+        }
+        0x03 => {
+            cpu.registers.dp &= !0x0F;
+        }
+        _ => unreachable!("value & 0x03 is always <= 0x03"),
+    }
+
+    let dph_adjust = ((opcode >> 9) & 0xF) as u16;
+    cpu.registers.dp ^= dph_adjust << 4;
+
+    let rp_adjust = opcode.bit(8);
+    if rp_adjust {
+        // TODO ST010/ST011 size
+        cpu.registers.rp = cpu.registers.rp.wrapping_sub(1) & 0x3FF;
+    }
+
+    let ret = opcode.bit(22);
+    if ret {
+        cpu.registers.pc = cpu.registers.pop_stack();
+    }
+
+    log::trace!(
+        "  ALU op: input={alu_input}, opcode={alu_opcode:02X}, accumulator={}, operand={operand:04X}, dpl_adjust={dpl_adjust}, dph_adjust={dph_adjust:X}, rp_adjust={rp_adjust}, ret={ret}",
+        if opcode.bit(15) { "B" } else { "A" }
+    );
+}
+
+fn or(accumulator: &mut i16, operand: i16, flags: &mut FlagsRegister) {
+    *accumulator |= operand;
+    *flags = FlagsRegister {
+        z: *accumulator == 0,
+        c: false,
+        s0: *accumulator < 0,
+        s1: *accumulator < 0,
+        ov0: false,
+        ov1: false,
+    };
+}
+
+fn and(accumulator: &mut i16, operand: i16, flags: &mut FlagsRegister) {
+    *accumulator &= operand;
+    *flags = FlagsRegister {
+        z: *accumulator == 0,
+        c: false,
+        s0: *accumulator < 0,
+        s1: *accumulator < 0,
+        ov0: false,
+        ov1: false,
+    };
+}
+
+fn xor(accumulator: &mut i16, operand: i16, flags: &mut FlagsRegister) {
+    *accumulator ^= operand;
+    *flags = FlagsRegister {
+        z: *accumulator == 0,
+        c: false,
+        s0: *accumulator < 0,
+        s1: *accumulator < 0,
+        ov0: false,
+        ov1: false,
+    };
+}
+
+fn sub(accumulator: &mut i16, operand: i16, borrow: bool, flags: &mut FlagsRegister) {
+    let (partial_unsigned_diff, carry1) = (*accumulator as u16).overflowing_sub(operand as u16);
+    let (unsigned_diff, carry2) = partial_unsigned_diff.overflowing_sub(borrow.into());
+    let new_borrow = carry1 || carry2;
+
+    let signed_diff = i32::from(*accumulator) - i32::from(operand) - i32::from(borrow);
+    let overflow = signed_diff < i16::MIN.into() || signed_diff > i16::MAX.into();
+
+    *accumulator = unsigned_diff as i16;
+    flags.z = *accumulator == 0;
+    flags.c = new_borrow;
+    flags.s0 = *accumulator < 0;
+    flags.ov0 = overflow;
+
+    if overflow {
+        flags.s1 = *accumulator < 0;
+        flags.ov1 = !flags.ov1;
+    }
+}
+
+fn add(accumulator: &mut i16, operand: i16, carry: bool, flags: &mut FlagsRegister) {
+    let (partial_unsigned_sum, carry1) = (*accumulator as u16).overflowing_add(operand as u16);
+    let (unsigned_sum, carry2) = partial_unsigned_sum.overflowing_add(carry.into());
+    let new_carry = carry1 || carry2;
+
+    let signed_sum = i32::from(*accumulator) + i32::from(operand) + i32::from(carry);
+    let overflow = signed_sum < i16::MIN.into() || signed_sum > i16::MAX.into();
+
+    *accumulator = unsigned_sum as i16;
+    flags.z = *accumulator == 0;
+    flags.c = new_carry;
+    flags.s0 = *accumulator < 0;
+    flags.ov0 = overflow;
+
+    if overflow {
+        flags.s1 = *accumulator < 0;
+        flags.ov1 = !flags.ov1;
+    }
+}
+
+fn not(accumulator: &mut i16, flags: &mut FlagsRegister) {
+    *accumulator = !(*accumulator);
+    *flags = FlagsRegister {
+        z: *accumulator == 0,
+        c: false,
+        s0: *accumulator < 0,
+        s1: *accumulator < 0,
+        ov0: false,
+        ov1: false,
+    };
+}
+
+fn sar1(accumulator: &mut i16, flags: &mut FlagsRegister) {
+    let carry = accumulator.bit(0);
+    *accumulator >>= 1;
+    *flags = FlagsRegister {
+        z: *accumulator == 0,
+        c: carry,
+        s0: *accumulator < 0,
+        s1: *accumulator < 0,
+        ov0: false,
+        ov1: false,
+    };
+}
+
+fn rcl1(accumulator: &mut i16, carry: bool, flags: &mut FlagsRegister) {
+    let new_carry = accumulator.sign_bit();
+    *accumulator = (*accumulator << 1) | i16::from(carry);
+    *flags = FlagsRegister {
+        z: *accumulator == 0,
+        c: new_carry,
+        s0: *accumulator < 0,
+        s1: *accumulator < 0,
+        ov0: false,
+        ov1: false,
+    };
+}
+
+fn sll2(accumulator: &mut i16, flags: &mut FlagsRegister) {
+    *accumulator = (*accumulator << 2) | 0x03;
+    *flags = FlagsRegister {
+        z: *accumulator == 0,
+        c: false,
+        s0: *accumulator < 0,
+        s1: *accumulator < 0,
+        ov0: false,
+        ov1: false,
+    };
+}
+
+fn sll4(accumulator: &mut i16, flags: &mut FlagsRegister) {
+    *accumulator = (*accumulator << 4) | 0x0F;
+    *flags = FlagsRegister {
+        z: *accumulator == 0,
+        c: false,
+        s0: *accumulator < 0,
+        s1: *accumulator < 0,
+        ov0: false,
+        ov1: false,
+    };
+}
+
+fn xchg(accumulator: &mut i16, flags: &mut FlagsRegister) {
+    *accumulator = accumulator.swap_bytes();
+    *flags = FlagsRegister {
+        z: *accumulator == 0,
+        c: false,
+        s0: *accumulator < 0,
+        s1: *accumulator < 0,
+        ov0: false,
+        ov1: false,
+    };
+}
+
+fn execute_load(cpu: &mut Upd77c25, opcode: u32) {
+    log::trace!("  Load opcode: {opcode:06X}");
+
+    let value = (opcode >> 6) as u16;
+    let dest = opcode & 0xF;
+    write_register(cpu, dest, value);
+}
+
+fn execute_jump(cpu: &mut Upd77c25, opcode: u32) {
+    log::trace!("  Jump opcode: {:03X}", (opcode >> 13) & 0x1FF);
+
+    let jump_addr = ((opcode >> 2) & 0x7FF) as u16;
+    let should_jump = match (opcode >> 13) & 0x1FF {
+        // JNCA / JCA
+        0x080 => !cpu.registers.flags_a.c,
+        0x082 => cpu.registers.flags_a.c,
+        // JNCB / JCB
+        0x084 => !cpu.registers.flags_b.c,
+        0x086 => cpu.registers.flags_b.c,
+        // JNZA / JZA
+        0x088 => !cpu.registers.flags_a.z,
+        0x08A => cpu.registers.flags_a.z,
+        // JNZB / JZB
+        0x08C => !cpu.registers.flags_b.z,
+        0x08E => cpu.registers.flags_b.z,
+        // JNOVA0 / JOVA0
+        0x090 => !cpu.registers.flags_a.ov0,
+        0x092 => cpu.registers.flags_a.ov0,
+        // JNOVB0 / JOVB0
+        0x094 => !cpu.registers.flags_b.ov0,
+        0x096 => cpu.registers.flags_b.ov0,
+        // JNOVA1 / JOVA1
+        0x098 => !cpu.registers.flags_a.ov1,
+        0x09A => cpu.registers.flags_a.ov1,
+        // JNOVB1 / JOVB1
+        0x09C => !cpu.registers.flags_b.ov1,
+        0x09E => cpu.registers.flags_b.ov1,
+        // JNSA0 / JSA0
+        0x0A0 => !cpu.registers.flags_a.s0,
+        0x0A2 => cpu.registers.flags_a.s0,
+        // JNSB0 / JSB0
+        0x0A4 => !cpu.registers.flags_b.s0,
+        0x0A6 => cpu.registers.flags_b.s0,
+        // JNSA1 / JSA1
+        0x0A8 => !cpu.registers.flags_a.s1,
+        0x0AA => cpu.registers.flags_a.s1,
+        // JNSB1 / JSB1
+        0x0AC => !cpu.registers.flags_b.s1,
+        0x0AE => cpu.registers.flags_b.s1,
+        // JDPL0 / JDPLN0
+        0x0B0 => cpu.registers.dp & 0x0F == 0,
+        0x0B1 => cpu.registers.dp & 0x0F != 0,
+        // JDPLF / JDPLNF
+        0x0B2 => cpu.registers.dp & 0x0F == 0x0F,
+        0x0B3 => cpu.registers.dp & 0x0F != 0x0F,
+        // JNSIAK / JSIAK / JNSOAK / JSOAK; not implemented
+        0x0B4 | 0x0B6 | 0x0B8 | 0x0BA => {
+            log::warn!("Unimplemented uPD77C25 jump opcode (serial registers): {opcode:06X}");
+            false
+        }
+        // JNRQM / JRQM
+        0x0BC => !cpu.registers.sr.request_for_master,
+        0x0BE => cpu.registers.sr.request_for_master,
+        // JMP
+        0x100 => true,
+        // CALL
+        0x140 => {
+            cpu.registers.push_stack(cpu.registers.pc);
+            true
+        }
+        _ => panic!("invalid uPD77C25 jump opcode: {opcode:06X}"),
+    };
+
+    if should_jump {
+        log::trace!("  Jumping to {jump_addr:03X}");
+
+        // TODO ST010/ST011 PC size
+        if jump_addr == cpu.registers.pc.wrapping_sub(1) & 0x7FF {
+            log::trace!("  Detected idle loop; halting CPU until next SNES DR write");
+            cpu.idling = true;
+        }
+
+        cpu.registers.pc = jump_addr;
+    }
+}
+
+fn read_register(cpu: &mut Upd77c25, register: u32) -> u16 {
+    log::trace!("  Reading register {register:02X}");
+
+    match register {
+        0x00 => cpu.registers.trb as u16,
+        0x01 => cpu.registers.accumulator_a as u16,
+        0x02 => cpu.registers.accumulator_b as u16,
+        0x03 => cpu.registers.tr as u16,
+        0x04 => cpu.registers.dp,
+        0x05 => cpu.registers.rp,
+        0x06 => cpu.data_rom[cpu.registers.rp as usize],
+        0x07 => 0x8000 - u16::from(cpu.registers.flags_a.s1),
+        0x08 => {
+            // Reading DR sets RQM
+            cpu.registers.sr.request_for_master = true;
+            cpu.registers.dr
+        }
+        0x09 => {
+            // Reading DRNF does not set RQM
+            cpu.registers.dr
+        }
+        0x0A => u16::from(u8::from(cpu.registers.sr)) << 8,
+        0x0B | 0x0C => {
+            // Serial registers; not implemented
+            0x0000
+        }
+        0x0D => cpu.registers.k as u16,
+        0x0E => cpu.registers.l as u16,
+        0x0F => cpu.ram[cpu.registers.dp as usize],
+        _ => panic!("invalid uPD77C25 register read: {register:02X}"),
+    }
+}
+
+#[allow(clippy::match_same_arms)]
+fn write_register(cpu: &mut Upd77c25, register: u32, value: u16) {
+    log::trace!("  Writing {value:04X} to register {register:02X}");
+
+    match register {
+        0x00 => {}
+        0x01 => cpu.registers.accumulator_a = value as i16,
+        0x02 => cpu.registers.accumulator_b = value as i16,
+        0x03 => cpu.registers.tr = value as i16,
+        // TODO ST010/ST011 size
+        0x04 => cpu.registers.dp = value & 0xFF,
+        // TODO ST010/ST011 size
+        0x05 => cpu.registers.rp = value & 0x3FF,
+        0x06 => cpu.registers.upd_write_data(value),
+        0x07 => cpu.registers.sr.write(value),
+        0x08 | 0x09 => {
+            // Serial registers; not implemented
+        }
+        0x0A => cpu.registers.k = value as i16,
+        0x0B => {
+            cpu.registers.k = value as i16;
+            cpu.registers.l = cpu.data_rom[cpu.registers.rp as usize] as i16;
+        }
+        0x0C => {
+            cpu.registers.l = value as i16;
+            cpu.registers.k = cpu.ram[(cpu.registers.dp | 0x40) as usize] as i16;
+        }
+        0x0D => cpu.registers.l = value as i16,
+        0x0E => cpu.registers.trb = value as i16,
+        0x0F => cpu.ram[cpu.registers.dp as usize] = value,
+        _ => panic!("invalid uPD77C25 register write: {register:02X} {value:04X}"),
+    }
+}

--- a/snes-core/src/lib.rs
+++ b/snes-core/src/lib.rs
@@ -2,6 +2,7 @@ pub mod api;
 mod apu;
 mod audio;
 mod bus;
+pub(crate) mod constants;
 mod coprocessors;
 pub mod input;
 mod memory;

--- a/snes-core/src/memory/cartridge.rs
+++ b/snes-core/src/memory/cartridge.rs
@@ -114,7 +114,7 @@ impl Cartridge {
 
             log::info!("Detected DSP coprocessor of type {dsp_variant}");
 
-            let dsp_rom = match dsp_variant {
+            let dsp_rom_fn = match dsp_variant {
                 DspVariant::Dsp1 => {
                     coprocessor_roms.dsp1.as_ref().ok_or(LoadError::MissingDsp1Rom)?
                 }
@@ -129,7 +129,10 @@ impl Cartridge {
                 }
             };
 
-            Some(Upd77c25::new(dsp_rom, Upd77c25Variant::Dsp))
+            let dsp_rom = dsp_rom_fn()
+                .map_err(|(source, path)| LoadError::CoprocessorRomLoad { source, path })?;
+
+            Some(Upd77c25::new(&dsp_rom, Upd77c25Variant::Dsp))
         } else {
             None
         };


### PR DESCRIPTION
The NEC µPD77C25/µPD96050 CPU was used in 6 different SNES coprocessor chips:
* DSP-1 (19 games, most notably _Super Mario Kart_ and _Pilotwings_)
* DSP-2 (1 game, _Dungeon Master_)
* DSP-3 (1 game, _SD Gundam GX_)
* DSP-4 (1 game, _Top Gear 3000_)
* ST010 (1 game, _F1 ROC II: Race of Champions_)
* ST011 (1 game, _Hayazashi Nidan Morita Shogi_)

The µPD96050 seems to be fully backwards-compatible with the µPD77C25, at least in how these games use them.

Unlike most other coprocessors, these are not fully programmable - the CPU executes from program ROM built into the chip. DSP-1, the most prolific of these chips, is programmed with geometric and trigonometric functions to aid in rendering pseudo-3D graphics in real time. Some of the others are programmed with routines to enable faster AI calculations. DSP-2 has routines to work with graphics in bitmap format.

DSP-1, DSP-2, DSP-3, and DSP-4 all use the µPD77C25, and they are virtually identical except for the program and data ROMs on the chip.

ST010 and ST011 use a more advanced version of the CPU, the NEC µPD96050, that supports higher clock speeds and has more ROM and RAM capacity. It also exposes its 4KB of RAM directly to the SNES CPU, unlike the DSP chips. The two chips are virtually identical except for the program/data ROMs and the clock speed: ST010 runs at ~10 MHz and ST011 runs at ~15 MHz.