### PR TITLE
Implement SNES SA-1 coprocessor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3002,6 +3002,7 @@ dependencies = [
  "jgenesis-common",
  "jgenesis-proc-macros",
  "log",
+ "rand",
  "serde",
  "spc700-emu",
  "thiserror",

--- a/snes-core/Cargo.toml
+++ b/snes-core/Cargo.toml
@@ -19,6 +19,7 @@ bincode = { workspace = true }
 bytemuck = { workspace = true }
 crc = { workspace = true }
 log = { workspace = true }
+rand = { workspace = true }
 serde = { workspace = true, optional = true }
 thiserror = { workspace = true }
 

--- a/snes-core/src/apu/dsp.rs
+++ b/snes-core/src/apu/dsp.rs
@@ -895,7 +895,7 @@ impl AudioDsp {
         let address = self.register_address & 0x7F;
 
         // High nibble of register address encodes the voice
-        let voice = (self.register_address >> 4) as usize;
+        let voice = (address >> 4) as usize;
 
         match address & 0x0F {
             0x00 => self.voices[voice].volume_l as u8,

--- a/snes-core/src/bus.rs
+++ b/snes-core/src/bus.rs
@@ -269,6 +269,16 @@ impl<'a> BusInterface for Bus<'a> {
 
     #[inline]
     fn irq(&self) -> bool {
-        self.cpu_registers.irq_pending()
+        self.cpu_registers.irq_pending() || self.memory.cartridge_irq()
+    }
+
+    #[inline]
+    fn halt(&self) -> bool {
+        false
+    }
+
+    #[inline]
+    fn reset(&self) -> bool {
+        false
     }
 }

--- a/snes-core/src/coprocessors.rs
+++ b/snes-core/src/coprocessors.rs
@@ -1,3 +1,4 @@
 pub mod cx4;
+pub mod sa1;
 pub mod sdd1;
 pub mod upd77c25;

--- a/snes-core/src/coprocessors/sa1.rs
+++ b/snes-core/src/coprocessors/sa1.rs
@@ -1,0 +1,101 @@
+mod bus;
+mod mmc;
+mod registers;
+mod timer;
+
+use crate::coprocessors::sa1::bus::Sa1Bus;
+use crate::coprocessors::sa1::mmc::Sa1Mmc;
+use crate::coprocessors::sa1::registers::Sa1Registers;
+use crate::coprocessors::sa1::timer::Sa1Timer;
+use crate::memory::cartridge::Rom;
+use bincode::{Decode, Encode};
+use jgenesis_common::frontend::TimingMode;
+use jgenesis_proc_macros::PartialClone;
+use std::mem;
+use wdc65816_emu::core::Wdc65816;
+
+const IRAM_LEN: usize = 2 * 1024;
+
+type Iram = [u8; IRAM_LEN];
+
+macro_rules! new_sa1_bus {
+    ($self:expr) => {
+        Sa1Bus {
+            rom: &$self.rom,
+            iram: &mut $self.iram,
+            bwram: &mut $self.bwram,
+            mmc: &mut $self.mmc,
+            registers: &mut $self.registers,
+            timer: &mut $self.timer,
+        }
+    };
+}
+
+#[derive(Debug, Clone, Encode, Decode, PartialClone)]
+pub struct Sa1 {
+    #[partial_clone(default)]
+    rom: Rom,
+    iram: Box<Iram>,
+    bwram: Box<[u8]>,
+    cpu: Wdc65816,
+    mmc: Sa1Mmc,
+    registers: Sa1Registers,
+    timer: Sa1Timer,
+}
+
+impl Sa1 {
+    pub fn new(rom: Rom, sram: Box<[u8]>, timing_mode: TimingMode) -> Self {
+        Self {
+            rom,
+            iram: vec![0; IRAM_LEN].into_boxed_slice().try_into().unwrap(),
+            bwram: sram,
+            cpu: Wdc65816::new(),
+            mmc: Sa1Mmc::new(),
+            registers: Sa1Registers::new(),
+            timer: Sa1Timer::new(timing_mode),
+        }
+    }
+
+    pub fn take_rom(&mut self) -> Vec<u8> {
+        mem::take(&mut self.rom.0).into_vec()
+    }
+
+    pub fn set_rom(&mut self, rom: Vec<u8>) {
+        self.rom.0 = rom.into_boxed_slice();
+    }
+
+    pub fn sram(&self) -> Option<&[u8]> {
+        (!self.bwram.is_empty()).then_some(self.bwram.as_ref())
+    }
+
+    pub fn tick(&mut self, master_cycles_elapsed: u64) {
+        assert_eq!(master_cycles_elapsed % 2, 0);
+
+        let mut bus = new_sa1_bus!(self);
+        for _ in 0..master_cycles_elapsed / 2 {
+            if !bus.registers.cpu_halted() {
+                self.cpu.tick(&mut bus);
+            }
+
+            bus.registers.tick(bus.mmc, bus.rom, bus.iram, bus.bwram);
+            bus.timer.tick();
+        }
+    }
+
+    pub fn snes_irq(&self) -> bool {
+        (self.registers.snes_irq_from_sa1_enabled && self.registers.snes_irq_from_sa1)
+            || (self.registers.snes_irq_from_dma_enabled && self.registers.character_conversion_irq)
+    }
+
+    pub fn reset(&mut self) {
+        self.registers.reset(&mut self.timer, &mut self.mmc);
+    }
+
+    pub fn notify_dma_start(&mut self, source_address: u32) {
+        self.registers.notify_snes_dma_start(source_address);
+    }
+
+    pub fn notify_dma_end(&mut self) {
+        self.registers.notify_snes_dma_end();
+    }
+}

--- a/snes-core/src/coprocessors/sa1/bus.rs
+++ b/snes-core/src/coprocessors/sa1/bus.rs
@@ -1,0 +1,289 @@
+use crate::coprocessors::sa1::mmc::{BwramBitmapBits, BwramMapSource, Sa1Mmc};
+use crate::coprocessors::sa1::registers::{InterruptVectorSource, Sa1Registers};
+use crate::coprocessors::sa1::timer::Sa1Timer;
+use crate::coprocessors::sa1::{Iram, Sa1};
+use wdc65816_emu::traits::BusInterface;
+
+impl Sa1 {
+    pub fn snes_read(&mut self, address: u32) -> Option<u8> {
+        let bank = (address >> 16) & 0xFF;
+        let offset = address & 0xFFFF;
+        match (bank, offset) {
+            (0x00..=0x3F | 0x80..=0xBF, 0x8000..=0xFFFF) | (0xC0..=0xFF, _) => {
+                // ROM
+
+                // Check for NMI/IRQ vector reads first
+                let nmi_vector_source = self.registers.snes_nmi_vector_source;
+                let irq_vector_source = self.registers.snes_irq_vector_source;
+                match (bank, offset) {
+                    (0x00, 0xFFEA) if nmi_vector_source == InterruptVectorSource::IoPorts => {
+                        Some(self.registers.snes_nmi_vector as u8)
+                    }
+                    (0x00, 0xFFEB) if nmi_vector_source == InterruptVectorSource::IoPorts => {
+                        Some((self.registers.snes_nmi_vector >> 8) as u8)
+                    }
+                    (0x00, 0xFFEE) if irq_vector_source == InterruptVectorSource::IoPorts => {
+                        Some(self.registers.snes_irq_vector as u8)
+                    }
+                    (0x00, 0xFFEF) if irq_vector_source == InterruptVectorSource::IoPorts => {
+                        Some((self.registers.snes_irq_vector >> 8) as u8)
+                    }
+                    _ => self
+                        .mmc
+                        .map_rom_address(address)
+                        .and_then(|rom_addr| self.rom.get(rom_addr as usize).copied()),
+                }
+            }
+            (0x00..=0x3F | 0x80..=0xBF, 0x2300..=0x230F) => {
+                // SA-1 internal registers
+                self.registers.snes_read(address)
+            }
+            (0x00..=0x3F | 0x80..=0xBF, 0x3000..=0x37FF) => {
+                // I-RAM
+                Some(self.iram[(address & 0x7FF) as usize])
+            }
+            (0x00..=0x3F | 0x80..=0xBF, 0x6000..=0x7FFF) => {
+                // BW-RAM 8KB block
+                let bwram_addr = (self.mmc.snes_bwram_base_addr | (address & 0x1FFF))
+                    & (self.bwram.len() as u32 - 1);
+                Some(self.bwram[bwram_addr as usize])
+            }
+            (0x40..=0x4F, _) => {
+                // BW-RAM in full
+                // If character conversion DMA type 1 is in progress, ignore the address and return
+                // the next CCDMA byte
+                if self.registers.ccdma_transfer_in_progress {
+                    Some(self.registers.next_ccdma_byte(&mut self.iram, &self.bwram))
+                } else {
+                    let bwram_addr = (address as usize) & (self.bwram.len() - 1);
+                    Some(self.bwram[bwram_addr])
+                }
+            }
+            _ => None,
+        }
+    }
+
+    pub fn snes_write(&mut self, address: u32, value: u8) {
+        let bank = (address >> 16) & 0xFF;
+        let offset = address & 0xFFFF;
+        match (bank, offset) {
+            (0x00..=0x3F | 0x80..=0xBF, 0x2200..=0x22FF) => {
+                // SA-1 internal registers
+                self.registers.snes_write(address, value, &mut self.mmc);
+            }
+            (0x00..=0x3F | 0x80..=0xBF, 0x3000..=0x37FF) => {
+                // I-RAM
+                let iram_addr = address & 0x7FF;
+                let write_protect_idx = iram_addr >> 8;
+                if self.registers.snes_iram_writes_enabled[write_protect_idx as usize] {
+                    self.iram[iram_addr as usize] = value;
+                }
+            }
+            (0x00..=0x3F | 0x80..=0xBF, 0x6000..=0x7FFF) => {
+                // BW-RAM 8KB block
+                let bwram_addr = (self.mmc.snes_bwram_base_addr | (address & 0x1FFF))
+                    & (self.bwram.len() as u32 - 1);
+                if self.registers.can_write_bwram(bwram_addr) {
+                    self.bwram[bwram_addr as usize] = value;
+                }
+            }
+            (0x40..=0x4F, _) => {
+                // BW-RAM in full
+                let bwram_addr = (address as usize) & (self.bwram.len() - 1);
+                if self.registers.can_write_bwram(bwram_addr as u32) {
+                    self.bwram[bwram_addr] = value;
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+pub(super) struct Sa1Bus<'a> {
+    pub(super) rom: &'a [u8],
+    pub(super) iram: &'a mut Iram,
+    pub(super) bwram: &'a mut [u8],
+    pub(super) mmc: &'a mut Sa1Mmc,
+    pub(super) registers: &'a mut Sa1Registers,
+    pub(super) timer: &'a mut Sa1Timer,
+}
+
+impl<'a> BusInterface for Sa1Bus<'a> {
+    #[inline]
+    fn read(&mut self, address: u32) -> u8 {
+        let bank = (address >> 16) & 0xFF;
+        let offset = address & 0xFFFF;
+        match (bank, offset) {
+            (0x00..=0x3F | 0x80..=0xBF, 0x8000..=0xFFFF) | (0xC0..=0xFF, _) => {
+                // ROM
+
+                // Check for NMI/IRQ/RESET vector reads first
+                match (bank, offset) {
+                    (0x00, 0xFFEA) => self.registers.sa1_nmi_vector as u8,
+                    (0x00, 0xFFEB) => (self.registers.sa1_nmi_vector >> 8) as u8,
+                    (0x00, 0xFFEE) => self.registers.sa1_irq_vector as u8,
+                    (0x00, 0xFFEF) => (self.registers.sa1_irq_vector >> 8) as u8,
+                    (0x00, 0xFFFC) => self.registers.sa1_reset_vector as u8,
+                    (0x00, 0xFFFD) => (self.registers.sa1_reset_vector >> 8) as u8,
+                    _ => self
+                        .mmc
+                        .map_rom_address(address)
+                        .and_then(|rom_addr| self.rom.get(rom_addr as usize).copied())
+                        .unwrap_or(0),
+                }
+            }
+            (0x00..=0x3F | 0x80..=0xBF, 0x2300..=0x230F) => {
+                // SA-1 internal registers
+                self.registers.sa1_read(address, self.timer)
+            }
+            (0x00..=0x3F | 0x80..=0xBF, 0x0000..=0x07FF | 0x3000..=0x37FF) => {
+                // I-RAM (mapped to both $0000-$07FF and $3000-$37FF for SA-1 CPU)
+                self.iram[(address & 0x7FF) as usize]
+            }
+            (0x00..=0x3F | 0x80..=0xBF, 0x6000..=0x7FFF) => {
+                // BW-RAM 8KB block
+                match self.mmc.sa1_bwram_source {
+                    BwramMapSource::Normal => {
+                        let bwram_addr = ((self.mmc.sa1_bwram_base_addr & 0x3E000)
+                            | (address & 0x01FFF))
+                            & (self.bwram.len() as u32 - 1);
+                        self.bwram[bwram_addr as usize]
+                    }
+                    BwramMapSource::Bitmap => {
+                        let bitmap_addr = self.mmc.sa1_bwram_base_addr | (address & 0x1FFF);
+                        read_bwram_bitmap(bitmap_addr, self.mmc, self.bwram)
+                    }
+                }
+            }
+            (0x40..=0x4F, _) => {
+                // BW-RAM in full
+                let bwram_addr = (address as usize) & (self.bwram.len() - 1);
+                self.bwram[bwram_addr]
+            }
+            (0x60..=0x6F, _) => {
+                // BW-RAM bitmap view
+                read_bwram_bitmap(address, self.mmc, self.bwram)
+            }
+            _ => 0,
+        }
+    }
+
+    #[inline]
+    fn write(&mut self, address: u32, value: u8) {
+        let bank = (address >> 16) & 0xFF;
+        let offset = address & 0xFFFF;
+        match (bank, offset) {
+            (0x00..=0x3F | 0x80..=0xBF, 0x2200..=0x22FF) => {
+                // SA-1 internal registers
+                self.registers.sa1_write(address, value, self.timer, self.mmc, self.rom, self.iram);
+            }
+            (0x00..=0x3F | 0x80..=0xBF, 0x0000..=0x07FF | 0x3000..=0x37FF) => {
+                // I-RAM (mapped to both $0000-$07FF and $3000-$37FF for SA-1 CPU)
+                let iram_addr = address & 0x7FF;
+                let write_protect_idx = iram_addr >> 8;
+                if self.registers.sa1_iram_writes_enabled[write_protect_idx as usize] {
+                    self.iram[iram_addr as usize] = value;
+                }
+            }
+            (0x00..=0x3F | 0x80..=0xBF, 0x6000..=0x7FFF) => {
+                // BW-RAM 8KB block
+                match self.mmc.sa1_bwram_source {
+                    BwramMapSource::Normal => {
+                        let bwram_addr = ((self.mmc.sa1_bwram_base_addr & 0x3E000)
+                            | (address & 0x01FFF))
+                            & (self.bwram.len() as u32 - 1);
+                        if self.registers.can_write_bwram(bwram_addr) {
+                            self.bwram[bwram_addr as usize] = value;
+                        }
+                    }
+                    BwramMapSource::Bitmap => {
+                        let bitmap_addr = self.mmc.sa1_bwram_base_addr | (address & 0x1FFF);
+                        write_bwram_bitmap(bitmap_addr, value, self.mmc, self.bwram);
+                    }
+                }
+            }
+            (0x40..=0x4F, _) => {
+                // BW-RAM in full (256KB max, mirrored every 4 banks)
+                let bwram_addr = (address as usize) & (self.bwram.len() - 1);
+                if self.registers.can_write_bwram(bwram_addr as u32) {
+                    self.bwram[bwram_addr] = value;
+                }
+            }
+            (0x60..=0x6F, _) => {
+                // BW-RAM bitmap view
+                write_bwram_bitmap(address, value, self.mmc, self.bwram);
+            }
+            _ => {}
+        }
+    }
+
+    #[inline]
+    fn idle(&mut self) {}
+
+    #[inline]
+    fn nmi(&self) -> bool {
+        self.registers.sa1_nmi_enabled && self.registers.sa1_nmi
+    }
+
+    #[inline]
+    fn acknowledge_nmi(&mut self) {}
+
+    #[inline]
+    fn irq(&self) -> bool {
+        (self.registers.sa1_irq_from_snes_enabled && self.registers.sa1_irq_from_snes)
+            || (self.registers.timer_irq_enabled && self.timer.irq_pending)
+            || (self.registers.dma_irq_enabled && self.registers.sa1_dma_irq)
+    }
+
+    #[inline]
+    fn halt(&self) -> bool {
+        self.registers.sa1_wait
+    }
+
+    #[inline]
+    fn reset(&self) -> bool {
+        self.registers.sa1_reset
+    }
+}
+
+fn read_bwram_bitmap(address: u32, mmc: &Sa1Mmc, bwram: &[u8]) -> u8 {
+    match mmc.bwram_bitmap_format {
+        BwramBitmapBits::Two => {
+            let address = address & 0xFFFFF;
+            let bwram_addr = (address >> 2) & (bwram.len() as u32 - 1);
+            let bwram_shift = 2 * (address & 0x03);
+
+            (bwram[bwram_addr as usize] >> bwram_shift) & 0x03
+        }
+        BwramBitmapBits::Four => {
+            let address = address & 0x7FFFF;
+            let bwram_addr = (address >> 1) & (bwram.len() as u32 - 1);
+            let bwram_shift = 4 * (address & 0x01);
+
+            (bwram[bwram_addr as usize] >> bwram_shift) & 0x0F
+        }
+    }
+}
+
+fn write_bwram_bitmap(address: u32, value: u8, mmc: &Sa1Mmc, bwram: &mut [u8]) {
+    match mmc.bwram_bitmap_format {
+        BwramBitmapBits::Two => {
+            let address = address & 0xFFFFF;
+            let bwram_addr = (address >> 2) & (bwram.len() as u32 - 1);
+            let shift = 2 * (address & 0x03);
+
+            let existing_value = bwram[bwram_addr as usize];
+            let new_value = (existing_value & !(0x03 << shift)) | ((value & 0x03) << shift);
+            bwram[bwram_addr as usize] = new_value;
+        }
+        BwramBitmapBits::Four => {
+            let address = address & 0x7FFFF;
+            let bwram_addr = (address >> 1) & (bwram.len() as u32 - 1);
+            let shift = 4 * (address & 0x01);
+
+            let existing_value = bwram[bwram_addr as usize];
+            let new_value = (existing_value & !(0x0F << shift)) | ((value & 0x0F) << shift);
+            bwram[bwram_addr as usize] = new_value;
+        }
+    }
+}

--- a/snes-core/src/coprocessors/sa1/mmc.rs
+++ b/snes-core/src/coprocessors/sa1/mmc.rs
@@ -1,0 +1,186 @@
+use bincode::{Decode, Encode};
+use jgenesis_common::num::GetBit;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Encode, Decode)]
+pub enum BwramMapSource {
+    #[default]
+    Normal,
+    Bitmap,
+}
+
+impl BwramMapSource {
+    fn from_bit(bit: bool) -> Self {
+        if bit { Self::Bitmap } else { Self::Normal }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Encode, Decode)]
+pub enum BwramBitmapBits {
+    Two,
+    #[default]
+    Four,
+}
+
+impl BwramBitmapBits {
+    fn from_bit(bit: bool) -> Self {
+        if bit { Self::Two } else { Self::Four }
+    }
+}
+
+const DEFAULT_BANK_C_ADDR: u32 = 0x000000;
+const DEFAULT_BANK_D_ADDR: u32 = 0x100000;
+const DEFAULT_BANK_E_ADDR: u32 = 0x200000;
+const DEFAULT_BANK_F_ADDR: u32 = 0x300000;
+
+#[derive(Debug, Clone, Encode, Decode)]
+pub struct Sa1Mmc {
+    pub bank_c_base_addr: u32,
+    pub bank_c_lorom_mapped: bool,
+    pub bank_d_base_addr: u32,
+    pub bank_d_lorom_mapped: bool,
+    pub bank_e_base_addr: u32,
+    pub bank_e_lorom_mapped: bool,
+    pub bank_f_base_addr: u32,
+    pub bank_f_lorom_mapped: bool,
+    pub snes_bwram_base_addr: u32,
+    pub sa1_bwram_base_addr: u32,
+    pub sa1_bwram_source: BwramMapSource,
+    pub bwram_bitmap_format: BwramBitmapBits,
+}
+
+impl Sa1Mmc {
+    pub fn new() -> Self {
+        Self {
+            bank_c_base_addr: DEFAULT_BANK_C_ADDR,
+            bank_c_lorom_mapped: false,
+            bank_d_base_addr: DEFAULT_BANK_D_ADDR,
+            bank_d_lorom_mapped: false,
+            bank_e_base_addr: DEFAULT_BANK_E_ADDR,
+            bank_e_lorom_mapped: false,
+            bank_f_base_addr: DEFAULT_BANK_F_ADDR,
+            bank_f_lorom_mapped: false,
+            snes_bwram_base_addr: 0,
+            sa1_bwram_base_addr: 0,
+            sa1_bwram_source: BwramMapSource::default(),
+            bwram_bitmap_format: BwramBitmapBits::default(),
+        }
+    }
+
+    pub fn map_rom_address(&self, address: u32) -> Option<u32> {
+        let bank = (address >> 16) & 0xFF;
+        let offset = address & 0xFFFF;
+        match (bank, offset) {
+            (0x00..=0x1F, 0x8000..=0xFFFF) => {
+                // LoROM bank C
+                let base_addr = self.lorom_bank_c_addr();
+                Some(lorom_map_address(base_addr, address))
+            }
+            (0x20..=0x3F, 0x8000..=0xFFFF) => {
+                // LoROM bank D
+                let base_addr = self.lorom_bank_d_addr();
+                Some(lorom_map_address(base_addr, address))
+            }
+            (0x80..=0x9F, 0x8000..=0xFFFF) => {
+                // LoROM bank E
+                let base_addr = self.lorom_bank_e_addr();
+                Some(lorom_map_address(base_addr, address))
+            }
+            (0xA0..=0xBF, 0x8000..=0xFFFF) => {
+                // LoROM bank F
+                let base_addr = self.lorom_bank_f_addr();
+                Some(lorom_map_address(base_addr, address))
+            }
+            (0xC0..=0xCF, _) => {
+                // HiROM bank C
+                Some(self.bank_c_base_addr | (address & 0xFFFFF))
+            }
+            (0xD0..=0xDF, _) => {
+                // HiROM bank D
+                Some(self.bank_d_base_addr | (address & 0xFFFFF))
+            }
+            (0xE0..=0xEF, _) => {
+                // HiROM bank E
+                Some(self.bank_e_base_addr | (address & 0xFFFFF))
+            }
+            (0xF0..=0xFF, _) => {
+                // HiROM bank F
+                Some(self.bank_f_base_addr | (address & 0xFFFFF))
+            }
+            _ => None,
+        }
+    }
+
+    fn lorom_bank_c_addr(&self) -> u32 {
+        if self.bank_c_lorom_mapped { self.bank_c_base_addr } else { DEFAULT_BANK_C_ADDR }
+    }
+
+    fn lorom_bank_d_addr(&self) -> u32 {
+        if self.bank_d_lorom_mapped { self.bank_d_base_addr } else { DEFAULT_BANK_D_ADDR }
+    }
+
+    fn lorom_bank_e_addr(&self) -> u32 {
+        if self.bank_e_lorom_mapped { self.bank_e_base_addr } else { DEFAULT_BANK_E_ADDR }
+    }
+
+    fn lorom_bank_f_addr(&self) -> u32 {
+        if self.bank_f_lorom_mapped { self.bank_f_base_addr } else { DEFAULT_BANK_F_ADDR }
+    }
+
+    pub fn write_cxb(&mut self, value: u8) {
+        self.bank_c_base_addr = u32::from(value & 0x07) << 20;
+        self.bank_c_lorom_mapped = value.bit(7);
+
+        log::trace!("  MMC bank C base address: {:06X}", self.bank_c_base_addr);
+        log::trace!("  MMC bank C LoROM mapped: {}", self.bank_c_lorom_mapped);
+    }
+
+    pub fn write_dxb(&mut self, value: u8) {
+        self.bank_d_base_addr = u32::from(value & 0x07) << 20;
+        self.bank_d_lorom_mapped = value.bit(7);
+
+        log::trace!("  MMC bank D base address: {:06X}", self.bank_d_base_addr);
+        log::trace!("  MMC bank D LoROM mapped: {}", self.bank_d_lorom_mapped);
+    }
+
+    pub fn write_exb(&mut self, value: u8) {
+        self.bank_e_base_addr = u32::from(value & 0x07) << 20;
+        self.bank_e_lorom_mapped = value.bit(7);
+
+        log::trace!("  MMC bank E base address: {:06X}", self.bank_e_base_addr);
+        log::trace!("  MMC bank E LoROM mapped: {}", self.bank_e_lorom_mapped);
+    }
+
+    pub fn write_fxb(&mut self, value: u8) {
+        self.bank_f_base_addr = u32::from(value & 0x07) << 20;
+        self.bank_f_lorom_mapped = value.bit(7);
+
+        log::trace!("  MMC bank F base address: {:06X}", self.bank_f_base_addr);
+        log::trace!("  MMC bank F LoROM mapped: {}", self.bank_f_lorom_mapped);
+    }
+
+    pub fn write_bmaps(&mut self, value: u8) {
+        self.snes_bwram_base_addr = u32::from(value & 0x1F) << 13;
+
+        log::trace!("  SNES BW-RAM base address: {:X}", self.snes_bwram_base_addr);
+    }
+
+    pub fn write_bmap(&mut self, value: u8) {
+        self.sa1_bwram_base_addr = u32::from(value & 0x7F) << 13;
+        self.sa1_bwram_source = BwramMapSource::from_bit(value.bit(7));
+
+        log::trace!("  SA-1 BW-RAM base address: {:X}", self.sa1_bwram_base_addr);
+        log::trace!("  SA-1 BW-RAM block source: {:?}", self.sa1_bwram_source);
+    }
+
+    pub fn write_bbf(&mut self, value: u8) {
+        self.bwram_bitmap_format = BwramBitmapBits::from_bit(value.bit(7));
+
+        log::trace!("  SA-1 BW-RAM bitmap format: {:?}", self.bwram_bitmap_format);
+    }
+}
+
+fn lorom_map_address(base_addr: u32, address: u32) -> u32 {
+    // A21-A23 come from MMC base address, but other than that this is standard LoROM mapping
+    // Ignore A15 and shift A16-A20 right by 1
+    base_addr | (address & 0x7FFF) | ((address & 0x1F0000) >> 1)
+}

--- a/snes-core/src/coprocessors/sa1/registers.rs
+++ b/snes-core/src/coprocessors/sa1/registers.rs
@@ -1,0 +1,1016 @@
+mod dma;
+
+use crate::coprocessors::sa1::mmc::Sa1Mmc;
+use crate::coprocessors::sa1::timer::Sa1Timer;
+use crate::coprocessors::sa1::Iram;
+use bincode::{Decode, Encode};
+use jgenesis_common::num::{GetBit, SignBit};
+use std::ops::Range;
+use std::{array, cmp};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Encode, Decode)]
+pub enum InterruptVectorSource {
+    #[default]
+    Rom,
+    IoPorts,
+}
+
+impl InterruptVectorSource {
+    fn from_bit(bit: bool) -> Self {
+        if bit { Self::IoPorts } else { Self::Rom }
+    }
+
+    fn to_bit(self) -> bool {
+        self == Self::IoPorts
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Encode, Decode)]
+pub enum DmaSourceDevice {
+    #[default]
+    Rom,
+    Iram,
+    Bwram,
+}
+
+impl DmaSourceDevice {
+    fn from_byte(byte: u8) -> Self {
+        match byte & 0x03 {
+            0x00 => Self::Rom,
+            0x01 => Self::Bwram,
+            0x02 => Self::Iram,
+            0x03 => {
+                log::warn!("SA-1 set unsupported DMA source 3; defaulting to ROM");
+                Self::Rom
+            }
+            _ => unreachable!("value & 0x03 is always <= 0x03"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Encode, Decode)]
+pub enum DmaDestinationDevice {
+    #[default]
+    Iram,
+    Bwram,
+}
+
+impl DmaDestinationDevice {
+    fn from_bit(bit: bool) -> Self {
+        if bit { Self::Bwram } else { Self::Iram }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Encode, Decode)]
+pub enum DmaType {
+    #[default]
+    Normal,
+    CharacterConversion,
+}
+
+impl DmaType {
+    fn from_bit(bit: bool) -> Self {
+        if bit { Self::CharacterConversion } else { Self::Normal }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Encode, Decode)]
+pub enum DmaPriority {
+    #[default]
+    Cpu,
+    Dma,
+}
+
+impl DmaPriority {
+    fn from_bit(bit: bool) -> Self {
+        if bit { Self::Dma } else { Self::Cpu }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Encode, Decode)]
+pub enum CharacterConversionType {
+    One,
+    #[default]
+    Two,
+}
+
+impl CharacterConversionType {
+    fn from_bit(bit: bool) -> Self {
+        if bit { Self::One } else { Self::Two }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Encode, Decode)]
+pub enum CharacterConversionColorBits {
+    Two,
+    Four,
+    #[default]
+    Eight,
+}
+
+impl CharacterConversionColorBits {
+    fn from_byte(byte: u8) -> Self {
+        match byte & 0x03 {
+            0x00 => Self::Eight,
+            0x01 => Self::Four,
+            0x02 | 0x03 => Self::Two,
+            _ => unreachable!("value & 0x03 is always <= 0x03"),
+        }
+    }
+
+    fn bit_mask(self) -> u8 {
+        match self {
+            Self::Two => 0x03,
+            Self::Four => 0x0F,
+            Self::Eight => 0xFF,
+        }
+    }
+
+    fn tile_size(self) -> u32 {
+        match self {
+            Self::Two => 16,
+            Self::Four => 32,
+            Self::Eight => 64,
+        }
+    }
+
+    fn bitplanes(self) -> u32 {
+        match self {
+            Self::Two => 2,
+            Self::Four => 4,
+            Self::Eight => 8,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Encode, Decode)]
+pub enum DmaState {
+    Idle,
+    NormalCopying,
+    NormalWaitCycle,
+    CharacterConversion2 { buffer_idx: u8, rows_copied: u8 },
+    CharacterConversion1Initial { cycles_remaining: u8 },
+    CharacterConversion1Active { buffer_idx: u8, dma_bytes_remaining: u8, next_tile_number: u16 },
+}
+
+impl Default for DmaState {
+    fn default() -> Self {
+        Self::Idle
+    }
+}
+
+impl DmaState {
+    fn is_character_conversion(self) -> bool {
+        matches!(
+            self,
+            Self::CharacterConversion2 { .. }
+                | Self::CharacterConversion1Initial { .. }
+                | Self::CharacterConversion1Active { .. }
+        )
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Encode, Decode)]
+pub enum ArithmeticOp {
+    #[default]
+    Multiply,
+    Divide,
+    MultiplyAccumulate,
+}
+
+impl ArithmeticOp {
+    fn from_byte(byte: u8) -> Self {
+        match byte & 0x03 {
+            0x00 => Self::Multiply,
+            0x01 => Self::Divide,
+            0x02 | 0x03 => Self::MultiplyAccumulate,
+            _ => unreachable!("value & 0x03 is always <= 0x03"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Encode, Decode)]
+pub struct Sa1Registers {
+    // CCNT / SA-1 CPU Control
+    pub sa1_irq_from_snes: bool,
+    pub sa1_nmi: bool,
+    pub sa1_reset: bool,
+    pub sa1_wait: bool,
+    pub message_to_sa1: u8,
+    // SCNT / SNES CPU Control
+    pub snes_irq_from_sa1: bool,
+    pub snes_irq_vector_source: InterruptVectorSource,
+    pub snes_nmi_vector_source: InterruptVectorSource,
+    pub message_to_snes: u8,
+    // SIE / SNES CPU Interrupt Enable
+    pub snes_irq_from_sa1_enabled: bool,
+    pub snes_irq_from_dma_enabled: bool,
+    // CIE / SA-1 CPU Interrupt Enable
+    pub sa1_irq_from_snes_enabled: bool,
+    pub timer_irq_enabled: bool,
+    pub dma_irq_enabled: bool,
+    pub sa1_nmi_enabled: bool,
+    // CRV / SA-1 CPU RESET Vector
+    pub sa1_reset_vector: u16,
+    // CNV / SA-1 CPU NMI Vector
+    pub sa1_nmi_vector: u16,
+    // CIV / SA-1 CPU IRQ Vector
+    pub sa1_irq_vector: u16,
+    // SNV / SNES CPU NMI Vector
+    pub snes_nmi_vector: u16,
+    // SIV / SNES CPU IRQ Vector
+    pub snes_irq_vector: u16,
+    // SBWE/CBWE / BW-RAM Writes Enabled
+    pub bwram_writes_enabled: bool,
+    // BWPA / BW-RAM Write Protected Area
+    pub bwram_write_protection_size: u32,
+    // SIWP / SNES I-RAM Write Protection
+    pub snes_iram_writes_enabled: [bool; 8],
+    // CIWP / SA-1 I-RAM Write Protection
+    pub sa1_iram_writes_enabled: [bool; 8],
+    // DCNT / DMA Control
+    pub dma_source: DmaSourceDevice,
+    pub dma_destination: DmaDestinationDevice,
+    pub dma_type: DmaType,
+    pub character_conversion_type: CharacterConversionType,
+    pub dma_priority: DmaPriority,
+    pub dma_enabled: bool,
+    // CDMA / Character Conversion DMA Parameters
+    pub ccdma_color_depth: CharacterConversionColorBits,
+    pub virtual_vram_width_tiles: u8,
+    // SDA / DMA Source Device Start Address
+    pub dma_source_address: u32,
+    // DDA / DMA Destination Device Start Address
+    pub dma_destination_address: u32,
+    // DTC / DMA Terminal Counter
+    pub dma_terminal_counter: u16,
+    // BRF / Bitmap Register File
+    pub bitmap_pixels: [u8; 16],
+    // MCNT / Arithmetic Control
+    pub arithmetic_op: ArithmeticOp,
+    // MA / Arithmetic Parameter A
+    pub arithmetic_param_a: u16,
+    // MB / Arithmetic Parameter B
+    pub arithmetic_param_b: u16,
+    // MR / Arithmetic Result
+    pub arithmetic_result: u64,
+    // OF / Arithmetic Overflow Flag
+    pub arithmetic_overflow: bool,
+    // VDA / Variable-Length Bit Data ROM Start Address
+    pub varlen_bit_start_address: u32,
+    // VDP / Variable-Length Bit Data Read Port
+    pub varlen_bit_data: u32,
+    pub varlen_bits_remaining: u8,
+    // TODO varlen auto-increment? not used by any games
+    // Miscellaneous internal state
+    pub dma_state: DmaState,
+    pub ccdma_transfer_in_progress: bool,
+    pub character_conversion_irq: bool,
+    pub sa1_dma_irq: bool,
+    pub arithmetic_cycles_remaining: u16,
+}
+
+impl Sa1Registers {
+    pub fn new() -> Self {
+        Self {
+            sa1_irq_from_snes: false,
+            sa1_nmi: false,
+            sa1_reset: true,
+            sa1_wait: false,
+            message_to_sa1: 0,
+            snes_irq_from_sa1: false,
+            snes_irq_vector_source: InterruptVectorSource::default(),
+            snes_nmi_vector_source: InterruptVectorSource::default(),
+            message_to_snes: 0,
+            snes_irq_from_sa1_enabled: false,
+            snes_irq_from_dma_enabled: false,
+            sa1_irq_from_snes_enabled: false,
+            timer_irq_enabled: false,
+            dma_irq_enabled: false,
+            sa1_nmi_enabled: false,
+            sa1_reset_vector: 0,
+            sa1_nmi_vector: 0,
+            sa1_irq_vector: 0,
+            snes_nmi_vector: 0,
+            snes_irq_vector: 0,
+            bwram_writes_enabled: false,
+            bwram_write_protection_size: 1 << 23,
+            snes_iram_writes_enabled: [false; 8],
+            sa1_iram_writes_enabled: [false; 8],
+            dma_source: DmaSourceDevice::default(),
+            dma_destination: DmaDestinationDevice::default(),
+            dma_type: DmaType::default(),
+            character_conversion_type: CharacterConversionType::default(),
+            dma_priority: DmaPriority::default(),
+            dma_enabled: false,
+            ccdma_color_depth: CharacterConversionColorBits::default(),
+            virtual_vram_width_tiles: 1,
+            dma_source_address: 0,
+            dma_destination_address: 0,
+            dma_terminal_counter: 0,
+            bitmap_pixels: [0; 16],
+            arithmetic_op: ArithmeticOp::default(),
+            arithmetic_param_a: 0,
+            arithmetic_param_b: 0,
+            arithmetic_result: 0,
+            arithmetic_overflow: false,
+            varlen_bit_start_address: 0,
+            varlen_bit_data: 0,
+            varlen_bits_remaining: 0,
+            dma_state: DmaState::default(),
+            ccdma_transfer_in_progress: false,
+            character_conversion_irq: false,
+            sa1_dma_irq: false,
+            arithmetic_cycles_remaining: 0,
+        }
+    }
+
+    pub fn snes_read(&self, address: u32) -> Option<u8> {
+        // Only $2300 (SFR) is readable by SNES CPU
+        // $230E is supposed to be a version code register, but hardware tests discovered that it
+        // is actually open bus
+        (address & 0xFFFF == 0x2300).then(|| self.read_sfr())
+    }
+
+    pub fn sa1_read(&self, address: u32, timer: &mut Sa1Timer) -> u8 {
+        log::trace!("SA-1 register read: {:04X}", address & 0xFFFF);
+
+        match address & 0xFFFF {
+            0x2301 => self.read_cfr(timer),
+            0x2302 => timer.read_hcr_low(),
+            0x2303 => timer.read_hcr_high(),
+            0x2304 => timer.read_vcr_low(),
+            0x2305 => timer.read_vcr_high(),
+            0x2306..=0x230A => self.read_mr(address),
+            0x230B => self.read_of(),
+            0x230C => self.read_vdp_low(),
+            0x230D => self.read_vdp_high(),
+            _ => 0,
+        }
+    }
+
+    pub fn snes_write(&mut self, address: u32, value: u8, mmc: &mut Sa1Mmc) {
+        log::trace!("SNES register write: {address:06X} {value:02X}");
+
+        match address & 0xFFFF {
+            0x2200 => self.write_ccnt(value),
+            0x2201 => self.write_sie(value),
+            0x2202 => self.write_sic(value),
+            0x2203 => self.write_crv_low(value),
+            0x2204 => self.write_crv_high(value),
+            0x2205 => self.write_cnv_low(value),
+            0x2206 => self.write_cnv_high(value),
+            0x2207 => self.write_civ_low(value),
+            0x2208 => self.write_civ_high(value),
+            0x2220 => mmc.write_cxb(value),
+            0x2221 => mmc.write_dxb(value),
+            0x2222 => mmc.write_exb(value),
+            0x2223 => mmc.write_fxb(value),
+            0x2224 => mmc.write_bmaps(value),
+            0x2226 => self.write_sbwe(value),
+            0x2228 => self.write_bwpa(value),
+            0x2229 => self.write_siwp(value),
+            0x2231 => self.write_cdma(value),
+            0x2232 => self.write_sda_low(value),
+            0x2233 => self.write_sda_mid(value),
+            0x2234 => self.write_sda_high(value),
+            0x2235 => self.write_dda_low(value),
+            0x2236 => self.write_dda_mid(value),
+            0x2237 => self.write_dda_high(value),
+            _ => {}
+        }
+    }
+
+    pub fn sa1_write(
+        &mut self,
+        address: u32,
+        value: u8,
+        timer: &mut Sa1Timer,
+        mmc: &mut Sa1Mmc,
+        rom: &[u8],
+        iram: &mut Iram,
+    ) {
+        log::trace!("SA-1 register write: {address:06X} {value:02X}");
+
+        match address & 0xFFFF {
+            0x2209 => self.write_scnt(value),
+            0x220A => self.write_cie(value),
+            0x220B => self.write_cic(value, timer),
+            0x220C => self.write_snv_low(value),
+            0x220D => self.write_snv_high(value),
+            0x220E => self.write_siv_low(value),
+            0x220F => self.write_siv_high(value),
+            0x2210 => timer.write_tmc(value),
+            0x2211 => timer.reset(),
+            0x2212 => timer.write_hcnt_low(value),
+            0x2213 => timer.write_hcnt_high(value),
+            0x2214 => timer.write_vcnt_low(value),
+            0x2215 => timer.write_vcnt_high(value),
+            0x2225 => mmc.write_bmap(value),
+            0x2227 => self.write_cbwe(value),
+            0x222A => self.write_ciwp(value),
+            0x2230 => self.write_dcnt(value),
+            0x2231 => self.write_cdma(value),
+            0x2232 => self.write_sda_low(value),
+            0x2233 => self.write_sda_mid(value),
+            0x2234 => self.write_sda_high(value),
+            0x2235 => self.write_dda_low(value),
+            0x2236 => self.write_dda_mid(value),
+            0x2237 => self.write_dda_high(value),
+            0x2238 => self.write_dtc_low(value),
+            0x2239 => self.write_dtc_high(value),
+            0x223F => mmc.write_bbf(value),
+            0x2240..=0x224F => self.write_brf(address, value, iram),
+            0x2250 => self.write_mcnt(value),
+            0x2251 => self.write_ma_low(value),
+            0x2252 => self.write_ma_high(value),
+            0x2253 => self.write_mb_low(value),
+            0x2254 => self.write_mb_high(value),
+            0x2258 => self.write_vbd(value, mmc, rom),
+            0x2259 => self.write_vda_low(value),
+            0x225A => self.write_vda_mid(value),
+            0x225B => self.write_vda_high(value, mmc, rom),
+            _ => {}
+        }
+    }
+
+    fn read_sfr(&self) -> u8 {
+        (u8::from(self.snes_irq_from_sa1) << 7)
+            | (u8::from(self.snes_irq_vector_source.to_bit()) << 6)
+            | (u8::from(self.character_conversion_irq) << 5)
+            | (u8::from(self.snes_nmi_vector_source.to_bit()) << 4)
+            | self.message_to_snes
+    }
+
+    fn read_cfr(&self, timer: &Sa1Timer) -> u8 {
+        (u8::from(self.sa1_irq_from_snes) << 7)
+            | (u8::from(timer.irq_pending) << 6)
+            | (u8::from(self.sa1_dma_irq) << 5)
+            | (u8::from(self.sa1_nmi) << 4)
+            | self.message_to_sa1
+    }
+
+    fn read_mr(&self, address: u32) -> u8 {
+        // $2306 is bits 0-7, $2307 is bits 8-15, $2308 is bits 16-23, etc.
+        let shift = 8 * ((address & 0xF) - 0x6);
+        (self.arithmetic_result >> shift) as u8
+    }
+
+    fn read_of(&self) -> u8 {
+        u8::from(self.arithmetic_overflow) << 7
+    }
+
+    fn read_vdp_low(&self) -> u8 {
+        self.varlen_bit_data as u8
+    }
+
+    fn read_vdp_high(&self) -> u8 {
+        (self.varlen_bit_data >> 8) as u8
+    }
+
+    fn write_ccnt(&mut self, value: u8) {
+        if value.bit(7) {
+            self.sa1_irq_from_snes = true;
+            log::trace!("  Generating SA-1 IRQ from SNES");
+        }
+
+        self.sa1_wait = value.bit(6);
+        self.sa1_reset = value.bit(5);
+
+        if value.bit(4) {
+            self.sa1_nmi = true;
+            log::trace!("  Generating SA-1 NMI");
+        }
+
+        self.message_to_sa1 = value & 0x0F;
+
+        log::trace!("  SA-1 wait: {}", self.sa1_wait);
+        log::trace!("  SA-1 reset: {}", self.sa1_reset);
+        log::trace!("  Message to SA-1: {:X}", self.message_to_sa1);
+    }
+
+    fn write_sie(&mut self, value: u8) {
+        self.snes_irq_from_sa1_enabled = value.bit(7);
+        self.snes_irq_from_dma_enabled = value.bit(5);
+
+        log::trace!("  SNES IRQs from SA-1 enabled: {}", self.snes_irq_from_sa1_enabled);
+        log::trace!(
+            "  SNES character conversion DMA IRQs enabled: {}",
+            self.snes_irq_from_dma_enabled
+        );
+    }
+
+    fn write_sic(&mut self, value: u8) {
+        if value.bit(7) {
+            self.snes_irq_from_sa1 = false;
+            log::trace!("  SNES IRQ from SA-1 cleared");
+        }
+        if value.bit(5) {
+            self.character_conversion_irq = false;
+            log::trace!("  SNES character conversion DMA IRQ cleared");
+        }
+    }
+
+    fn write_cie(&mut self, value: u8) {
+        self.sa1_irq_from_snes_enabled = value.bit(7);
+        self.timer_irq_enabled = value.bit(6);
+        self.dma_irq_enabled = value.bit(5);
+        self.sa1_nmi_enabled = value.bit(4);
+
+        log::trace!("  SA-1 IRQs from SNES enabled: {}", self.sa1_irq_from_snes_enabled);
+        log::trace!("  SA-1 timer IRQs enabled: {}", self.timer_irq_enabled);
+        log::trace!("  SA-1 DMA IRQs enabled: {}", self.dma_irq_enabled);
+        log::trace!("  SA-1 NMIs enabled: {}", self.sa1_nmi_enabled);
+    }
+
+    fn write_cic(&mut self, value: u8, timer: &mut Sa1Timer) {
+        if value.bit(7) {
+            self.sa1_irq_from_snes = false;
+            log::trace!("  Cleared SA-1 IRQ from SNES");
+        }
+
+        if value.bit(6) {
+            timer.irq_pending = false;
+            log::trace!("  Cleared SA-1 timer IRQ");
+        }
+
+        if value.bit(5) {
+            self.sa1_dma_irq = false;
+            log::trace!("  Cleared SA-1 DMA IRQ");
+        }
+
+        if value.bit(4) {
+            self.sa1_nmi = false;
+            log::trace!("  Cleared SA-1 NMI");
+        }
+    }
+
+    fn write_crv_low(&mut self, value: u8) {
+        self.sa1_reset_vector = (self.sa1_reset_vector & 0xFF00) | u16::from(value);
+
+        log::trace!("  SA-1 RESET vector: {:04X}", self.sa1_reset_vector);
+    }
+
+    fn write_crv_high(&mut self, value: u8) {
+        self.sa1_reset_vector = (self.sa1_reset_vector & 0x00FF) | (u16::from(value) << 8);
+
+        log::trace!("  SA-1 RESET vector: {:04X}", self.sa1_reset_vector);
+    }
+
+    fn write_cnv_low(&mut self, value: u8) {
+        self.sa1_nmi_vector = (self.sa1_nmi_vector & 0xFF00) | u16::from(value);
+
+        log::trace!("  SA-1 NMI vector: {:04X}", self.sa1_nmi_vector);
+    }
+
+    fn write_cnv_high(&mut self, value: u8) {
+        self.sa1_nmi_vector = (self.sa1_nmi_vector & 0x00FF) | (u16::from(value) << 8);
+
+        log::trace!("  SA-1 NMI vector: {:04X}", self.sa1_nmi_vector);
+    }
+
+    fn write_civ_low(&mut self, value: u8) {
+        self.sa1_irq_vector = (self.sa1_irq_vector & 0xFF00) | u16::from(value);
+
+        log::trace!("  SA-1 IRQ vector: {:04X}", self.sa1_irq_vector);
+    }
+
+    fn write_civ_high(&mut self, value: u8) {
+        self.sa1_irq_vector = (self.sa1_irq_vector & 0x00FF) | (u16::from(value) << 8);
+
+        log::trace!("  SA-1 IRQ vector: {:04X}", self.sa1_irq_vector);
+    }
+
+    fn write_snv_low(&mut self, value: u8) {
+        self.snes_nmi_vector = (self.snes_nmi_vector & 0xFF00) | u16::from(value);
+
+        log::trace!("  SNES NMI vector: {:04X}", self.snes_nmi_vector);
+    }
+
+    fn write_snv_high(&mut self, value: u8) {
+        self.snes_nmi_vector = (self.snes_nmi_vector & 0x00FF) | (u16::from(value) << 8);
+
+        log::trace!("  SNES NMI vector: {:04X}", self.snes_nmi_vector);
+    }
+
+    fn write_siv_low(&mut self, value: u8) {
+        self.snes_irq_vector = (self.snes_irq_vector & 0xFF00) | u16::from(value);
+
+        log::trace!("  SNES IRQ vector: {:04X}", self.snes_irq_vector);
+    }
+
+    fn write_siv_high(&mut self, value: u8) {
+        self.snes_irq_vector = (self.snes_irq_vector & 0x00FF) | (u16::from(value) << 8);
+
+        log::trace!("  SNES IRQ vector: {:04X}", self.snes_irq_vector);
+    }
+
+    fn write_scnt(&mut self, value: u8) {
+        if value.bit(7) {
+            self.snes_irq_from_sa1 = true;
+            log::trace!("  Generated SNES IRQ from SA-1");
+        }
+
+        self.snes_irq_vector_source = InterruptVectorSource::from_bit(value.bit(6));
+        self.snes_nmi_vector_source = InterruptVectorSource::from_bit(value.bit(4));
+        self.message_to_snes = value & 0x0F;
+
+        log::trace!("  SNES IRQ vector source: {:?}", self.snes_irq_vector_source);
+        log::trace!("  SNES NMI vector source: {:?}", self.snes_nmi_vector_source);
+        log::trace!("  Message to SNES: {:X}", self.message_to_snes);
+    }
+
+    fn write_sbwe(&mut self, value: u8) {
+        self.bwram_writes_enabled = value.bit(7);
+
+        log::trace!("  BW-RAM writes enabled: {}", self.bwram_writes_enabled);
+    }
+
+    fn write_cbwe(&mut self, value: u8) {
+        self.bwram_writes_enabled = value.bit(7);
+
+        log::trace!("  BW-RAM writes enabled: {}", self.bwram_writes_enabled);
+    }
+
+    fn write_bwpa(&mut self, value: u8) {
+        // Write protected area size is 256 * 2^N bytes
+        self.bwram_write_protection_size = 1 << (8 + (value & 0x0F));
+
+        log::trace!("  BW-RAM write protection size: {:X}", self.bwram_write_protection_size);
+    }
+
+    fn write_siwp(&mut self, value: u8) {
+        self.snes_iram_writes_enabled = array::from_fn(|i| value.bit(i as u8));
+
+        log::trace!("  SNES I-RAM writes enabled: {value:02X}");
+    }
+
+    fn write_ciwp(&mut self, value: u8) {
+        self.sa1_iram_writes_enabled = array::from_fn(|i| value.bit(i as u8));
+
+        log::trace!("  SA-1 I-RAM writes enabled: {value:02X}");
+    }
+
+    fn write_dcnt(&mut self, value: u8) {
+        self.dma_source = DmaSourceDevice::from_byte(value);
+        self.dma_destination = DmaDestinationDevice::from_bit(value.bit(2));
+        self.character_conversion_type = CharacterConversionType::from_bit(value.bit(4));
+        self.dma_type = DmaType::from_bit(value.bit(5));
+        self.dma_priority = DmaPriority::from_bit(value.bit(6));
+        self.dma_enabled = value.bit(7);
+
+        log::trace!("  DMA source: {:?}", self.dma_source);
+        log::trace!("  DMA destination: {:?}", self.dma_destination);
+        log::trace!("  DMA character conversion type: {:?}", self.character_conversion_type);
+        log::trace!("  DMA type: {:?}", self.dma_type);
+        log::trace!("  DMA enabled: {}", self.dma_enabled);
+    }
+
+    fn write_cdma(&mut self, value: u8) {
+        self.ccdma_color_depth = CharacterConversionColorBits::from_byte(value);
+        self.virtual_vram_width_tiles = cmp::min(32, 1 << ((value >> 2) & 0x07));
+
+        if value.bit(7) && self.dma_state.is_character_conversion() {
+            log::trace!("  Terminating character conversion DMA");
+            self.dma_state = DmaState::Idle;
+        }
+
+        log::trace!("  Character conversion DMA color depth bits: {:?}", self.ccdma_color_depth);
+        log::trace!("  Virtual VRAM width in tiles: {}", self.virtual_vram_width_tiles);
+    }
+
+    fn write_sda_low(&mut self, value: u8) {
+        self.dma_source_address = (self.dma_source_address & 0xFFFF00) | u32::from(value);
+
+        log::trace!("  DMA source address: {:06X}", self.dma_source_address);
+    }
+
+    fn write_sda_mid(&mut self, value: u8) {
+        self.dma_source_address = (self.dma_source_address & 0xFF00FF) | (u32::from(value) << 8);
+
+        log::trace!("  DMA source address: {:06X}", self.dma_source_address);
+    }
+
+    fn write_sda_high(&mut self, value: u8) {
+        self.dma_source_address = (self.dma_source_address & 0x00FFFF) | (u32::from(value) << 16);
+
+        log::trace!("  DMA source address: {:06X}", self.dma_source_address);
+    }
+
+    fn write_dda_low(&mut self, value: u8) {
+        self.dma_destination_address = (self.dma_destination_address & 0xFFFF00) | u32::from(value);
+
+        log::trace!("  DMA destination address: {:06X}", self.dma_destination_address);
+    }
+
+    fn write_dda_mid(&mut self, value: u8) {
+        self.dma_destination_address =
+            (self.dma_destination_address & 0xFF00FF) | (u32::from(value) << 8);
+
+        log::trace!("  DMA destination address: {:06X}", self.dma_destination_address);
+
+        match (self.dma_enabled, self.dma_type, self.dma_destination) {
+            (true, DmaType::Normal, DmaDestinationDevice::Iram) => {
+                log::trace!("  Starting SA-1 DMA to I-RAM");
+                self.dma_state = DmaState::NormalCopying;
+            }
+            (true, DmaType::CharacterConversion, _) => {
+                log::trace!("  Starting character conversion DMA");
+                self.dma_state = match self.character_conversion_type {
+                    CharacterConversionType::Two => {
+                        DmaState::CharacterConversion2 { buffer_idx: 0, rows_copied: 0 }
+                    }
+                    CharacterConversionType::One => DmaState::CharacterConversion1Initial {
+                        cycles_remaining: self.ccdma_color_depth.tile_size() as u8,
+                    },
+                };
+            }
+            _ => {}
+        }
+    }
+
+    fn write_dda_high(&mut self, value: u8) {
+        self.dma_destination_address =
+            (self.dma_destination_address & 0x00FFFF) | (u32::from(value) << 16);
+
+        log::trace!("  DMA destination address: {:06X}", self.dma_destination_address);
+
+        if self.dma_enabled
+            && self.dma_type == DmaType::Normal
+            && self.dma_destination == DmaDestinationDevice::Bwram
+        {
+            log::trace!("  Starting SA-1 DMA to BW-RAM");
+            self.dma_state = DmaState::NormalCopying;
+        }
+    }
+
+    fn write_dtc_low(&mut self, value: u8) {
+        self.dma_terminal_counter = (self.dma_terminal_counter & 0xFF00) | u16::from(value);
+
+        log::trace!("  DMA terminal counter: {:04X}", self.dma_terminal_counter);
+    }
+
+    fn write_dtc_high(&mut self, value: u8) {
+        self.dma_terminal_counter = (self.dma_terminal_counter & 0x00FF) | (u16::from(value) << 8);
+
+        log::trace!("  DMA terminal counter: {:04X}", self.dma_terminal_counter);
+    }
+
+    fn write_brf(&mut self, address: u32, value: u8, iram: &mut Iram) {
+        // BRF registers are $2240-$224F; lowest 4 bits of address are the register index
+        let idx = (address & 0xF) as usize;
+        self.bitmap_pixels[idx] = value & self.ccdma_color_depth.bit_mask();
+
+        log::trace!("  Bitmap register file #{idx}: {value:02X}");
+
+        if idx & 0x7 == 0x7 {
+            // Perform character conversion any time register 7 or 15 is written
+            if let DmaState::CharacterConversion2 { buffer_idx, rows_copied } = self.dma_state {
+                self.character_conversion_2(idx & 0x8, buffer_idx, rows_copied, iram);
+            }
+        }
+    }
+
+    fn write_mcnt(&mut self, value: u8) {
+        self.arithmetic_op = ArithmeticOp::from_byte(value);
+
+        // Setting multiply-accumulate clears result
+        if self.arithmetic_op == ArithmeticOp::MultiplyAccumulate {
+            self.arithmetic_result = 0;
+            self.arithmetic_overflow = false;
+        }
+
+        log::trace!("  Arithmetic mode: {:?}", self.arithmetic_op);
+    }
+
+    fn write_ma_low(&mut self, value: u8) {
+        self.arithmetic_param_a = (self.arithmetic_param_a & 0xFF00) | u16::from(value);
+
+        log::trace!("  Arithmetic parameter A: {:04X}", self.arithmetic_param_a);
+    }
+
+    fn write_ma_high(&mut self, value: u8) {
+        self.arithmetic_param_a = (self.arithmetic_param_a & 0x00FF) | (u16::from(value) << 8);
+
+        log::trace!("  Arithmetic parameter A: {:04X}", self.arithmetic_param_a);
+    }
+
+    fn write_mb_low(&mut self, value: u8) {
+        self.arithmetic_param_b = (self.arithmetic_param_b & 0xFF00) | u16::from(value);
+
+        log::trace!("  Arithmetic parameter B: {:04X}", self.arithmetic_param_b);
+    }
+
+    fn write_mb_high(&mut self, value: u8) {
+        self.arithmetic_param_b = (self.arithmetic_param_b & 0x00FF) | (u16::from(value) << 8);
+
+        // Writing MB high byte begins arithmetic operation
+        self.arithmetic_cycles_remaining = match self.arithmetic_op {
+            ArithmeticOp::Multiply | ArithmeticOp::Divide => 5,
+            ArithmeticOp::MultiplyAccumulate => 6,
+        };
+
+        log::trace!("  Arithmetic parameter B: {:04X}", self.arithmetic_param_b);
+    }
+
+    fn write_vbd(&mut self, value: u8, mmc: &Sa1Mmc, rom: &[u8]) {
+        let shift = if value & 0x0F == 0 { 16 } else { value & 0x0F };
+        self.varlen_bit_data >>= shift;
+        self.varlen_bits_remaining -= shift;
+
+        if self.varlen_bits_remaining < 16 {
+            // Read next word
+            let word = mmc.map_rom_address(self.varlen_bit_start_address).map_or(0, |rom_addr| {
+                let lsb = rom.get(rom_addr as usize).copied().unwrap_or(0);
+                let msb = rom.get((rom_addr + 1) as usize).copied().unwrap_or(0);
+                u16::from_le_bytes([lsb, msb])
+            });
+            let word: u32 = word.into();
+
+            self.varlen_bit_data |= word << self.varlen_bits_remaining;
+            self.varlen_bit_start_address = (self.varlen_bit_start_address + 2) & 0xFFFFFF;
+            self.varlen_bits_remaining += 16;
+        }
+
+        log::trace!("  Variable-length bit data shift: {shift}");
+    }
+
+    fn write_vda_low(&mut self, value: u8) {
+        self.varlen_bit_start_address =
+            (self.varlen_bit_start_address & 0xFFFF00) | u32::from(value);
+
+        log::trace!(
+            "  Variable-length bit data ROM start address: {:06X}",
+            self.varlen_bit_start_address
+        );
+    }
+
+    fn write_vda_mid(&mut self, value: u8) {
+        self.varlen_bit_start_address =
+            (self.varlen_bit_start_address & 0xFF00FF) | (u32::from(value) << 8);
+
+        log::trace!(
+            "  Variable-length bit data ROM start address: {:06X}",
+            self.varlen_bit_start_address
+        );
+    }
+
+    fn write_vda_high(&mut self, value: u8, mmc: &Sa1Mmc, rom: &[u8]) {
+        self.varlen_bit_start_address =
+            (self.varlen_bit_start_address & 0x00FFFF) | (u32::from(value) << 16);
+
+        // Writing MSB starts the variable-length bit data read
+        if let Some(rom_addr) = mmc.map_rom_address(self.varlen_bit_start_address) {
+            let lsb = rom[rom_addr as usize];
+            let msb = rom.get((rom_addr + 1) as usize).copied().unwrap_or(0);
+            self.varlen_bit_data = u16::from_le_bytes([lsb, msb]).into();
+            self.varlen_bit_start_address = (self.varlen_bit_start_address + 2) & 0xFFFFFF;
+            self.varlen_bits_remaining = 16;
+        }
+
+        log::trace!(
+            "  Variable-length bit data ROM start address: {:06X}",
+            self.varlen_bit_start_address
+        );
+    }
+
+    pub fn can_write_bwram(&self, bwram_addr: u32) -> bool {
+        self.bwram_writes_enabled || bwram_addr >= self.bwram_write_protection_size
+    }
+
+    pub fn tick(&mut self, mmc: &Sa1Mmc, rom: &[u8], iram: &mut Iram, bwram: &mut [u8]) {
+        // Progress normal DMA or character conversion DMA type 1
+        match self.dma_state {
+            DmaState::NormalCopying => {
+                self.progress_normal_dma(mmc, rom, iram, bwram);
+            }
+            DmaState::NormalWaitCycle => {
+                self.dma_state = DmaState::NormalCopying;
+            }
+            DmaState::CharacterConversion1Initial { cycles_remaining } => {
+                if cycles_remaining == 1 {
+                    self.start_ccdma_type_1(iram, bwram);
+                } else {
+                    self.dma_state = DmaState::CharacterConversion1Initial {
+                        cycles_remaining: cycles_remaining - 1,
+                    };
+                }
+            }
+            DmaState::Idle
+            | DmaState::CharacterConversion2 { .. }
+            | DmaState::CharacterConversion1Active { .. } => {}
+        }
+
+        // Progress arithmetic operation
+        if self.arithmetic_cycles_remaining != 0 {
+            self.arithmetic_cycles_remaining -= 1;
+            if self.arithmetic_cycles_remaining == 0 {
+                self.perform_arithmetic_op();
+            }
+        }
+    }
+
+    pub fn notify_snes_dma_start(&mut self, source_address: u32) {
+        // TODO check exact source address?
+        if matches!(self.dma_state, DmaState::CharacterConversion1Active { .. })
+            && (0x400000..0x500000).contains(&source_address)
+        {
+            self.ccdma_transfer_in_progress = true;
+        }
+    }
+
+    pub fn notify_snes_dma_end(&mut self) {
+        self.ccdma_transfer_in_progress = false;
+    }
+
+    fn perform_arithmetic_op(&mut self) {
+        const I40_RANGE: Range<i64> = -(1 << 39)..1 << 39;
+        const I40_MASK: u64 = (1 << 40) - 1;
+
+        match self.arithmetic_op {
+            ArithmeticOp::Multiply => {
+                // Signed 16-bit x Signed 16-bit -> Signed 32-bit
+                self.arithmetic_result =
+                    (multiply(self.arithmetic_param_a, self.arithmetic_param_b) as u64) & I40_MASK;
+            }
+            ArithmeticOp::Divide => {
+                // Signed 16-bit / Unsigned 16-bit -> Signed 16-bit Quotient, Unsigned 16-bit Remainder
+                let (quotient, remainder) =
+                    divide(self.arithmetic_param_a, self.arithmetic_param_b);
+                let quotient: u64 = (quotient as u16).into();
+                let remainder: u64 = remainder.into();
+
+                self.arithmetic_result = quotient | (remainder << 16);
+
+                // Division apparently clears parameter A in addition to B
+                self.arithmetic_param_a = 0;
+            }
+            ArithmeticOp::MultiplyAccumulate => {
+                // Signed 16-bit x Signed 16-bit -> Signed 32-bit
+                // Accumulates into a signed 40-bit sum
+                let product = multiply(self.arithmetic_param_a, self.arithmetic_param_b);
+                let sum = (((self.arithmetic_result as i64) << 24) >> 24) + product;
+
+                self.arithmetic_result = (sum as u64) & I40_MASK;
+                self.arithmetic_overflow = !I40_RANGE.contains(&sum);
+            }
+        }
+
+        // All ops apparently clear parameter B
+        self.arithmetic_param_b = 0;
+    }
+
+    pub fn reset(&mut self, timer: &mut Sa1Timer, mmc: &mut Sa1Mmc) {
+        self.write_ccnt(0x20);
+        self.write_sie(0x00);
+        self.write_sic(0x00);
+        self.write_scnt(0x00);
+        self.write_cie(0x00);
+        self.write_cic(0x00, timer);
+        timer.write_tmc(0x00);
+        self.write_sbwe(0x00);
+        self.write_cbwe(0x00);
+        self.write_bwpa(0xFF);
+        self.write_siwp(0x00);
+        self.write_ciwp(0x00);
+        self.write_dcnt(0x00);
+        self.write_cdma(0x80);
+        self.write_mcnt(0x00);
+
+        mmc.write_cxb(0x00);
+        mmc.write_dxb(0x01);
+        mmc.write_exb(0x02);
+        mmc.write_fxb(0x03);
+        mmc.write_bmaps(0x00);
+        mmc.write_bmap(0x00);
+        mmc.write_bbf(0x00);
+    }
+
+    pub fn cpu_halted(&self) -> bool {
+        matches!(self.dma_state, DmaState::NormalCopying | DmaState::NormalWaitCycle)
+            && (self.dma_priority == DmaPriority::Dma || self.dma_source == DmaSourceDevice::Rom)
+    }
+}
+
+fn multiply(a: u16, b: u16) -> i64 {
+    let a: i64 = (a as i16).into();
+    let b: i64 = (b as i16).into();
+    a * b
+}
+
+fn divide(a: u16, b: u16) -> (i16, u16) {
+    if b == 0 {
+        // Divide by zero
+        return if a.sign_bit() { (1, (!a).wrapping_add(1)) } else { (-1, a) };
+    }
+
+    // Signed dividend, unsigned divisor
+    let a: i32 = (a as i16).into();
+    let b: i32 = b.into();
+
+    // Signed quotient, unsigned remainder
+    let quotient = a.div_euclid(b);
+    let remainder = a.rem_euclid(b);
+
+    (quotient as i16, remainder as u16)
+}

--- a/snes-core/src/coprocessors/sa1/registers/dma.rs
+++ b/snes-core/src/coprocessors/sa1/registers/dma.rs
@@ -1,0 +1,245 @@
+use crate::coprocessors::sa1::mmc::Sa1Mmc;
+use crate::coprocessors::sa1::registers::{
+    CharacterConversionColorBits, DmaDestinationDevice, DmaSourceDevice, DmaState, Sa1Registers,
+};
+use crate::coprocessors::sa1::Iram;
+use jgenesis_common::num::GetBit;
+
+impl Sa1Registers {
+    pub fn next_ccdma_byte(&mut self, iram: &mut Iram, bwram: &[u8]) -> u8 {
+        let DmaState::CharacterConversion1Active {
+            buffer_idx,
+            dma_bytes_remaining,
+            next_tile_number,
+        } = self.dma_state
+        else {
+            log::error!(
+                "next_ccdma_byte() called while CCDMA type 1 is not active; current DMA state is {:?}",
+                self.dma_state
+            );
+            return 0;
+        };
+
+        let tile_size = self.ccdma_color_depth.tile_size();
+        let base_iram_addr = (self.dma_destination_address & self.ccdma_dest_addr_mask())
+            + u32::from(buffer_idx) * tile_size;
+        let iram_addr = base_iram_addr + tile_size - u32::from(dma_bytes_remaining);
+        let next_byte = iram[iram_addr as usize];
+
+        if dma_bytes_remaining == 1 {
+            self.progress_ccdma_type_1(buffer_idx, next_tile_number, iram, bwram);
+        } else {
+            self.dma_state = DmaState::CharacterConversion1Active {
+                buffer_idx,
+                dma_bytes_remaining: dma_bytes_remaining - 1,
+                next_tile_number,
+            };
+        }
+
+        next_byte
+    }
+
+    pub(super) fn progress_normal_dma(
+        &mut self,
+        mmc: &Sa1Mmc,
+        rom: &[u8],
+        iram: &mut Iram,
+        bwram: &mut [u8],
+    ) {
+        let source_byte = match self.dma_source {
+            DmaSourceDevice::Rom => {
+                let Some(rom_addr) = mmc.map_rom_address(self.dma_source_address) else {
+                    self.dma_state = DmaState::Idle;
+                    return;
+                };
+                rom.get(rom_addr as usize).copied().unwrap_or(0)
+            }
+            DmaSourceDevice::Iram => {
+                let iram_addr = self.dma_source_address & 0x7FF;
+                iram[iram_addr as usize]
+            }
+            DmaSourceDevice::Bwram => {
+                let bwram_addr = (self.dma_source_address as usize) & (bwram.len() - 1);
+                bwram[bwram_addr]
+            }
+        };
+
+        match self.dma_destination {
+            DmaDestinationDevice::Iram => {
+                let iram_addr = self.dma_destination_address & 0x7FF;
+                iram[iram_addr as usize] = source_byte;
+            }
+            DmaDestinationDevice::Bwram => {
+                let bwram_addr = (self.dma_destination_address as usize) & (bwram.len() - 1);
+                bwram[bwram_addr] = source_byte;
+            }
+        }
+
+        self.dma_source_address = (self.dma_source_address + 1) & 0xFFFFFF;
+        self.dma_destination_address = (self.dma_destination_address + 1) & 0xFFFFFF;
+        self.dma_terminal_counter = self.dma_terminal_counter.wrapping_sub(1);
+
+        self.dma_state = match (self.dma_terminal_counter, self.dma_source, self.dma_destination) {
+            (0, _, _) => DmaState::Idle,
+            (_, DmaSourceDevice::Rom, DmaDestinationDevice::Iram) => DmaState::NormalCopying,
+            _ => DmaState::NormalWaitCycle,
+        };
+
+        if self.dma_state == DmaState::Idle {
+            log::trace!("SA-1 DMA complete");
+            self.sa1_dma_irq = true;
+        }
+    }
+
+    pub(super) fn character_conversion_2(
+        &mut self,
+        base_idx: usize,
+        buffer_idx: u8,
+        rows_copied: u8,
+        iram: &mut Iram,
+    ) {
+        let buffer_idx: u32 = buffer_idx.into();
+        let rows_copied: u32 = rows_copied.into();
+
+        let color_depth = self.ccdma_color_depth;
+        let tile_size = color_depth.tile_size();
+
+        let base_iram_addr =
+            (self.dma_destination_address & 0x7FF) + buffer_idx * tile_size + 2 * rows_copied;
+
+        // Convert 8 packed pixels to 1 row in an SNES tile
+        for pixel_idx in 0..8 {
+            let pixel = self.bitmap_pixels[base_idx + pixel_idx];
+            let shift = 7 - pixel_idx;
+
+            for plane in (0..color_depth.bitplanes()).step_by(2) {
+                let iram_addr = base_iram_addr + 8 * plane;
+
+                iram[iram_addr as usize] = (iram[iram_addr as usize] & !(1 << shift))
+                    | (u8::from(pixel.bit(plane as u8)) << shift);
+                iram[(iram_addr + 1) as usize] = (iram[(iram_addr + 1) as usize] & !(1 << shift))
+                    | (u8::from(pixel.bit((plane + 1) as u8)) << shift);
+            }
+        }
+
+        let rows_copied = ((rows_copied + 1) & 0x07) as u8;
+        let buffer_idx = (if rows_copied == 0 { 1 - buffer_idx } else { buffer_idx }) as u8;
+        self.dma_state = DmaState::CharacterConversion2 { buffer_idx, rows_copied }
+    }
+
+    pub(super) fn start_ccdma_type_1(&mut self, iram: &mut Iram, bwram: &[u8]) {
+        let source_addr =
+            self.dma_source_address & (bwram.len() as u32 - 1) & self.ccdma_source_addr_mask();
+        let dest_addr = self.dma_destination_address & self.ccdma_dest_addr_mask();
+
+        character_conversion_1_copy_tile(
+            source_addr,
+            dest_addr,
+            0,
+            self.ccdma_color_depth,
+            self.virtual_vram_width_tiles.into(),
+            iram,
+            bwram,
+        );
+
+        self.dma_state = DmaState::CharacterConversion1Active {
+            buffer_idx: 0,
+            dma_bytes_remaining: self.ccdma_color_depth.tile_size() as u8,
+            next_tile_number: 1,
+        };
+
+        log::trace!("CCDMA type 1 initial copy completed; generating IRQ");
+        self.character_conversion_irq = true;
+    }
+
+    fn progress_ccdma_type_1(
+        &mut self,
+        buffer_idx: u8,
+        next_tile_number: u16,
+        iram: &mut Iram,
+        bwram: &[u8],
+    ) {
+        // Invert buffer index
+        let buffer_idx: u32 = (1 - buffer_idx).into();
+
+        let source_addr =
+            self.dma_source_address & (bwram.len() as u32 - 1) & self.ccdma_source_addr_mask();
+        let dest_addr = (self.dma_destination_address & self.ccdma_dest_addr_mask())
+            + buffer_idx * self.ccdma_color_depth.tile_size();
+        character_conversion_1_copy_tile(
+            source_addr,
+            dest_addr,
+            next_tile_number.into(),
+            self.ccdma_color_depth,
+            self.virtual_vram_width_tiles.into(),
+            iram,
+            bwram,
+        );
+
+        self.dma_state = DmaState::CharacterConversion1Active {
+            buffer_idx: buffer_idx as u8,
+            dma_bytes_remaining: self.ccdma_color_depth.tile_size() as u8,
+            next_tile_number: next_tile_number + 1,
+        };
+    }
+
+    fn ccdma_source_addr_mask(&self) -> u32 {
+        let shift = self.ccdma_color_depth.bitplanes().trailing_zeros()
+            + self.virtual_vram_width_tiles.trailing_zeros()
+            + 3;
+        !((1 << shift) - 1)
+    }
+
+    fn ccdma_dest_addr_mask(&self) -> u32 {
+        match self.ccdma_color_depth {
+            CharacterConversionColorBits::Two => !((1 << 5) - 1),
+            CharacterConversionColorBits::Four => !((1 << 6) - 1),
+            CharacterConversionColorBits::Eight => !((1 << 7) - 1),
+        }
+    }
+}
+
+fn character_conversion_1_copy_tile(
+    source_addr: u32,
+    dest_addr: u32,
+    tile_number: u32,
+    color_depth: CharacterConversionColorBits,
+    vram_width: u32,
+    iram: &mut Iram,
+    bwram: &[u8],
+) {
+    let bitplanes = color_depth.bitplanes();
+    let pixels_per_byte = 8 / bitplanes;
+    let pixel_mask = if bitplanes == 8 { 0xFF } else { (1 << bitplanes) - 1 };
+
+    let source_tile_addr = source_addr
+        + (tile_number & (vram_width - 1)) * bitplanes
+        + tile_number / vram_width * color_depth.tile_size() * vram_width;
+
+    for line in 0..8 {
+        let source_line_addr = source_tile_addr + line * bitplanes * vram_width;
+        let dest_line_addr = dest_addr + 2 * line;
+
+        for pixel in 0..8 {
+            let pixel_addr = source_line_addr + pixel / pixels_per_byte;
+            let pixel_shift = match color_depth {
+                CharacterConversionColorBits::Two => 2 * (3 - (pixel % 4)),
+                CharacterConversionColorBits::Four => 4 * (1 - (pixel % 2)),
+                CharacterConversionColorBits::Eight => 0,
+            };
+
+            let bm_pixel = (bwram[pixel_addr as usize] >> pixel_shift) & pixel_mask;
+            let bm_shift = 7 - pixel;
+
+            for plane in (0..bitplanes).step_by(2) {
+                let iram_addr = dest_line_addr + 8 * plane;
+
+                iram[iram_addr as usize] = (iram[iram_addr as usize] & !(1 << bm_shift))
+                    | (u8::from(bm_pixel.bit(plane as u8)) << bm_shift);
+                iram[(iram_addr + 1) as usize] = (iram[(iram_addr + 1) as usize]
+                    & !(1 << bm_shift))
+                    | (u8::from(bm_pixel.bit((plane + 1) as u8)) << bm_shift);
+            }
+        }
+    }
+}

--- a/snes-core/src/coprocessors/sa1/timer.rs
+++ b/snes-core/src/coprocessors/sa1/timer.rs
@@ -1,0 +1,182 @@
+use bincode::{Decode, Encode};
+use jgenesis_common::frontend::TimingMode;
+use jgenesis_common::num::GetBit;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Encode, Decode)]
+pub enum TimerMode {
+    #[default]
+    HV,
+    Linear,
+}
+
+impl TimerMode {
+    fn from_bit(bit: bool) -> Self {
+        if bit { Self::Linear } else { Self::HV }
+    }
+
+    const fn max_h(self) -> u16 {
+        match self {
+            Self::HV => 341,
+            Self::Linear => 512,
+        }
+    }
+
+    fn max_v(self, timing_mode: TimingMode) -> u16 {
+        match (self, timing_mode) {
+            (Self::HV, TimingMode::Ntsc) => 262,
+            (Self::HV, TimingMode::Pal) => 312,
+            (Self::Linear, _) => 512,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Encode, Decode)]
+pub enum TimerIrqMode {
+    #[default]
+    Off,
+    H,
+    V,
+    HV,
+}
+
+impl TimerIrqMode {
+    fn from_byte(byte: u8) -> Self {
+        match byte & 0x03 {
+            0x00 => Self::Off,
+            0x01 => Self::H,
+            0x02 => Self::V,
+            0x03 => Self::HV,
+            _ => unreachable!("value & 0x03 is always <= 0x03"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Encode, Decode)]
+pub struct Sa1Timer {
+    pub mode: TimerMode,
+    pub irq_mode: TimerIrqMode,
+    pub timing_mode: TimingMode,
+    pub h_cpu_ticks: u16,
+    pub v: u16,
+    pub max_h_cpu_ticks: u16,
+    pub max_v: u16,
+    pub irq_htime_cpu_ticks: u16,
+    pub irq_vtime: u16,
+    pub irq_pending: bool,
+    pub latched_h: u16,
+    pub latched_v: u16,
+}
+
+impl Sa1Timer {
+    pub fn new(timing_mode: TimingMode) -> Self {
+        Self {
+            mode: TimerMode::default(),
+            irq_mode: TimerIrqMode::default(),
+            timing_mode,
+            h_cpu_ticks: 0,
+            v: 0,
+            max_h_cpu_ticks: TimerMode::default().max_h() << 1,
+            max_v: TimerMode::default().max_v(timing_mode),
+            irq_htime_cpu_ticks: 0,
+            irq_vtime: 0,
+            irq_pending: false,
+            latched_h: 0,
+            latched_v: 0,
+        }
+    }
+
+    pub fn read_hcr_low(&mut self) -> u8 {
+        // Reading HCR low byte latches both H and V
+        self.latched_h = self.h_cpu_ticks >> 1;
+        self.latched_v = self.v;
+
+        self.latched_h as u8
+    }
+
+    pub fn read_hcr_high(&self) -> u8 {
+        (self.latched_h >> 8) as u8
+    }
+
+    pub fn read_vcr_low(&self) -> u8 {
+        self.latched_v as u8
+    }
+
+    pub fn read_vcr_high(&self) -> u8 {
+        (self.latched_v >> 8) as u8
+    }
+
+    pub fn write_tmc(&mut self, value: u8) {
+        self.mode = TimerMode::from_bit(value.bit(7));
+        self.irq_mode = TimerIrqMode::from_byte(value);
+
+        if self.irq_mode == TimerIrqMode::Off {
+            self.irq_pending = false;
+        }
+
+        self.max_h_cpu_ticks = self.mode.max_h() << 1;
+        self.max_v = self.mode.max_v(self.timing_mode);
+
+        log::trace!("  H/V timer mode: {:?}", self.mode);
+        log::trace!("  H/V IRQ mode: {:?}", self.irq_mode);
+    }
+
+    pub fn write_hcnt_low(&mut self, value: u8) {
+        let htime = ((self.irq_htime_cpu_ticks >> 1) & 0x100) | u16::from(value);
+        self.irq_htime_cpu_ticks = (htime << 1) | (self.irq_htime_cpu_ticks & 0x1);
+
+        log::trace!("  IRQ HTIME: {}", self.irq_htime_cpu_ticks >> 1);
+    }
+
+    pub fn write_hcnt_high(&mut self, value: u8) {
+        let htime = ((self.irq_htime_cpu_ticks >> 1) & 0x0FF) | (u16::from(value & 0x01) << 8);
+        self.irq_htime_cpu_ticks = (htime << 1) | (self.irq_htime_cpu_ticks & 0x1);
+
+        log::trace!("  IRQ HTIME: {}", self.irq_htime_cpu_ticks >> 1);
+    }
+
+    pub fn write_vcnt_low(&mut self, value: u8) {
+        self.irq_vtime = (self.irq_vtime & 0x100) | u16::from(value);
+
+        log::trace!("  IRQ VTIME: {}", self.irq_vtime);
+    }
+
+    pub fn write_vcnt_high(&mut self, value: u8) {
+        self.irq_vtime = (self.irq_vtime & 0x0FF) | (u16::from(value & 0x01) << 8);
+
+        log::trace!("  IRQ VTIME: {}", self.irq_vtime);
+    }
+
+    pub fn tick(&mut self) {
+        self.h_cpu_ticks += 1;
+
+        if self.h_cpu_ticks >= self.max_h_cpu_ticks {
+            self.h_cpu_ticks -= self.max_h_cpu_ticks;
+            self.v += 1;
+
+            if self.v >= self.max_v {
+                self.v = 0;
+            }
+
+            if self.irq_mode == TimerIrqMode::V && self.v == self.irq_vtime {
+                self.irq_pending = true;
+            }
+        }
+
+        match self.irq_mode {
+            TimerIrqMode::H if self.h_cpu_ticks == self.irq_htime_cpu_ticks => {
+                self.irq_pending = true;
+            }
+            TimerIrqMode::HV
+                if self.h_cpu_ticks == self.irq_htime_cpu_ticks && self.v == self.irq_vtime =>
+            {
+                self.irq_pending = true;
+            }
+            _ => {}
+        }
+    }
+
+    pub fn reset(&mut self) {
+        self.h_cpu_ticks = 0;
+        self.v = 0;
+    }
+}

--- a/snes-core/src/memory.rs
+++ b/snes-core/src/memory.rs
@@ -80,6 +80,10 @@ impl Memory {
         self.cartridge.write(address, value);
     }
 
+    pub fn cartridge_irq(&self) -> bool {
+        self.cartridge.irq()
+    }
+
     pub fn cartridge_title(&mut self) -> String {
         // Cartridge title is always at $00FFC0-$00FFD4 (inclusive)
         let mut title_bytes = [0; 0xFFD4 - 0xFFC0 + 1];

--- a/wdc65816-emu/src/traits.rs
+++ b/wdc65816-emu/src/traits.rs
@@ -12,4 +12,8 @@ pub trait BusInterface {
     fn acknowledge_nmi(&mut self);
 
     fn irq(&self) -> bool;
+
+    fn halt(&self) -> bool;
+
+    fn reset(&self) -> bool;
 }

--- a/wdc65816-test-runner/src/bus.rs
+++ b/wdc65816-test-runner/src/bus.rs
@@ -44,4 +44,12 @@ impl BusInterface for RecordingBus {
     fn irq(&self) -> bool {
         false
     }
+
+    fn halt(&self) -> bool {
+        false
+    }
+
+    fn reset(&self) -> bool {
+        false
+    }
 }


### PR DESCRIPTION
The SA-1 (Super Accelerator 1) is a coprocessor that most notably adds a second 65C816 CPU, this one clocked at 10.74 MHz - a whopping 3-4x faster than the SNES CPU (3x at fast memory access speed, 4x at cartridge/WRAM access speed).

The SNES CPU can halt and reset the SA-1 CPU, but beyond that the two CPUs operate independently and can communicate through I/O ports, software interrupts, and shared cartridge RAM. The SA-1 CPU can access anything in the cartridge but it cannot access WRAM, the PPU, the APU, or the SNES CPU internal registers/ports.

Other SA-1 features:
* 2KB of I-RAM (instruction RAM)
* Up to 256KB of BW-RAM (backup/work RAM), generally battery-backed
* ROM bank switching using an MMC, supporting 1MB ROM banks in both the LoROM and HiROM areas
* Multiplication and division units for the SA-1 CPU that are _significantly_ faster than the SNES CPU's multiplication and division units, and also support higher bit-width operands and results
  * The SA-1 multiplier unit also supports a multiply-accumulate operation, which the SNES multiplier unit does not
* The ability to override the SNES CPU's NMI and IRQ vectors
* "Virtual VRAM", a view of BW-RAM that automatically unpacks 2bpp/4bpp bitmap packed pixel data
* DMA transfers from ROM to I-RAM, from ROM to BW-RAM, and between I-RAM and BW-RAM
* Character conversion DMA, a feature where the SA-1 hardware converts bitmap pixel data to the SNES tile format on-the-fly while the SNES is reading data via SNES DMA
* Variable-length bit data reading, which allows the SA-1 CPU to read data from ROM as if it were a bitstream
* An H/V timer for the SA-1 CPU that mimics the SNES H/V timer, and can also be configured to simply count from 0 to 511 in H and V

Most of the SA-1 features were used by very few games; most games simply took advantage of the additional faster CPU. For example, only 1 game uses variable-length bit data reading, only 3 games use "normal" SA-1 DMA, and only 3 games use character conversion DMA.

This coprocessor was the most widely used coprocessor at 35 games, with the most well-known being _Kirby Super Star_, _Kirby's Dream Land 3_, and _Super Mario RPG_.

![Screenshot from 2023-11-17 18-49-44](https://github.com/jsgroth/jgenesis/assets/1137683/d729f59a-ad82-467b-8dd3-d3877a849cd9)
