### PR TITLE
WIP: Implement SNES Super FX coprocessor

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Cross-platform multi-console emulator that supports the Sega Genesis / Mega Driv
   * Sega Master System / Mark III
   * Game Gear
   * Super Nintendo Entertainment System (SNES) / Super Famicom
-    * Some coprocessors are not currently implemented (Super FX, SA-1, etc.), and any games that used them will not currently work
+    * A few obscure coprocessors are not currently implemented (SPC7110, OBJ-1, S-RTC, ST018)
 * GPU-based renderer with integer prescaling and optional linear interpolation
 * Configurable pixel aspect ratio for each console with several different options: accurate to original hardware/TVs, square pixels, and stretched to fill the window
 * Support for the Sega Master System FM sound unit expansion
@@ -23,7 +23,6 @@ Cross-platform multi-console emulator that supports the Sega Genesis / Mega Driv
 
 TODOs:
 * Support multiple Sega CD BIOS versions in GUI and automatically use the correct one based on disc region
-* Implement SNES coprocessors, at least the ones that were used in popular games (e.g. Super FX)
 * Support CHD files for Sega CD in addition to BIN/CUE
 * Investigate and fix a few minor issues, like the EA logo flickering for a single frame in _Galahad_
 * Support 24C64 EEPROM chips (used only in _Frank Thomas Big Hurt Baseball_ and _College Slam_)

--- a/jgenesis-cli/src/main.rs
+++ b/jgenesis-cli/src/main.rs
@@ -19,6 +19,7 @@ use smsgg_core::psg::PsgVersion;
 use smsgg_core::{SmsRegion, VdpVersion};
 use snes_core::api::SnesAspectRatio;
 use std::ffi::OsStr;
+use std::num::NonZeroU64;
 use std::path::Path;
 use std::process;
 
@@ -137,6 +138,10 @@ struct Args {
     /// Disable hack that times SNES audio signal to 60Hz instead of ~60.098Hz
     #[arg(long = "no-snes-audio-60hz-hack", default_value_t = true, action = clap::ArgAction::SetFalse, help_heading = SNES_OPTIONS_HEADING)]
     snes_audio_60hz_hack: bool,
+
+    /// Speed multiplier for the Super FX GSU
+    #[arg(long, default_value_t = NonZeroU64::new(1).unwrap(), help_heading = SNES_OPTIONS_HEADING)]
+    gsu_overclock_factor: NonZeroU64,
 
     /// Specify SNES DSP-1 ROM path (required for DSP-1 games)
     #[arg(long, help_heading = SNES_OPTIONS_HEADING)]
@@ -579,6 +584,7 @@ fn run_snes(args: Args) -> anyhow::Result<()> {
         forced_timing_mode: args.snes_timing_mode,
         aspect_ratio: args.snes_aspect_ratio,
         audio_60hz_hack: args.snes_audio_60hz_hack,
+        gsu_overclock_factor: args.gsu_overclock_factor,
         dsp1_rom_path: args.dsp1_rom_path,
         dsp2_rom_path: args.dsp2_rom_path,
         dsp3_rom_path: args.dsp3_rom_path,

--- a/jgenesis-gui/src/app.rs
+++ b/jgenesis-gui/src/app.rs
@@ -30,7 +30,7 @@ use std::cell::RefCell;
 use std::collections::HashSet;
 use std::ffi::OsStr;
 use std::fs;
-use std::num::NonZeroU32;
+use std::num::{NonZeroU32, NonZeroU64};
 use std::ops::{Deref, DerefMut};
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
@@ -196,12 +196,18 @@ struct SnesAppConfig {
     aspect_ratio: SnesAspectRatio,
     #[serde(default = "true_fn")]
     audio_60hz_hack: bool,
+    #[serde(default = "default_gsu_overclock")]
+    gsu_overclock_factor: NonZeroU64,
     dsp1_rom_path: Option<String>,
     dsp2_rom_path: Option<String>,
     dsp3_rom_path: Option<String>,
     dsp4_rom_path: Option<String>,
     st010_rom_path: Option<String>,
     st011_rom_path: Option<String>,
+}
+
+fn default_gsu_overclock() -> NonZeroU64 {
+    NonZeroU64::new(1).unwrap()
 }
 
 impl Default for SnesAppConfig {
@@ -370,6 +376,7 @@ impl AppConfig {
             forced_timing_mode: self.snes.forced_timing_mode,
             aspect_ratio: self.snes.aspect_ratio,
             audio_60hz_hack: self.snes.audio_60hz_hack,
+            gsu_overclock_factor: self.snes.gsu_overclock_factor,
             dsp1_rom_path: self.snes.dsp1_rom_path.clone(),
             dsp2_rom_path: self.snes.dsp2_rom_path.clone(),
             dsp3_rom_path: self.snes.dsp3_rom_path.clone(),
@@ -710,6 +717,33 @@ impl App {
                         &mut self.config.snes.forced_timing_mode,
                         Some(TimingMode::Pal),
                         "PAL",
+                    );
+                });
+            });
+
+            ui.group(|ui| {
+                ui.label("Super FX GSU overclock factor");
+
+                ui.horizontal(|ui| {
+                    ui.radio_value(
+                        &mut self.config.snes.gsu_overclock_factor,
+                        NonZeroU64::new(1).unwrap(),
+                        "None",
+                    );
+                    ui.radio_value(
+                        &mut self.config.snes.gsu_overclock_factor,
+                        NonZeroU64::new(2).unwrap(),
+                        "2x",
+                    );
+                    ui.radio_value(
+                        &mut self.config.snes.gsu_overclock_factor,
+                        NonZeroU64::new(3).unwrap(),
+                        "3x",
+                    );
+                    ui.radio_value(
+                        &mut self.config.snes.gsu_overclock_factor,
+                        NonZeroU64::new(4).unwrap(),
+                        "4x",
                     );
                 });
             });

--- a/jgenesis-native-driver/src/config.rs
+++ b/jgenesis-native-driver/src/config.rs
@@ -16,6 +16,7 @@ use smsgg_core::psg::PsgVersion;
 use smsgg_core::{SmsGgEmulatorConfig, SmsRegion, VdpVersion};
 use snes_core::api::{CoprocessorRomFn, CoprocessorRoms, SnesAspectRatio, SnesEmulatorConfig};
 use std::fs;
+use std::num::NonZeroU64;
 
 pub(crate) const DEFAULT_GENESIS_WINDOW_SIZE: WindowSize = WindowSize { width: 878, height: 672 };
 
@@ -224,6 +225,7 @@ pub struct SnesConfig {
     pub forced_timing_mode: Option<TimingMode>,
     pub aspect_ratio: SnesAspectRatio,
     pub audio_60hz_hack: bool,
+    pub gsu_overclock_factor: NonZeroU64,
     pub dsp1_rom_path: Option<String>,
     pub dsp2_rom_path: Option<String>,
     pub dsp3_rom_path: Option<String>,
@@ -238,6 +240,7 @@ impl SnesConfig {
             forced_timing_mode: self.forced_timing_mode,
             aspect_ratio: self.aspect_ratio,
             audio_60hz_hack: self.audio_60hz_hack,
+            gsu_overclock_factor: self.gsu_overclock_factor,
         }
     }
 

--- a/jgenesis-web/src/config.rs
+++ b/jgenesis-web/src/config.rs
@@ -10,6 +10,7 @@ use smsgg_core::{SmsGgEmulatorConfig, SmsRegion, VdpVersion};
 use snes_core::api::{SnesAspectRatio, SnesEmulatorConfig};
 use std::cell::RefCell;
 use std::collections::VecDeque;
+use std::num::NonZeroU64;
 use std::ops::Deref;
 use std::rc::Rc;
 use wasm_bindgen::prelude::*;
@@ -172,6 +173,7 @@ impl SnesWebConfig {
             forced_timing_mode: None,
             aspect_ratio: self.aspect_ratio,
             audio_60hz_hack: true,
+            gsu_overclock_factor: NonZeroU64::new(1).unwrap(),
         }
     }
 }

--- a/snes-coprocessors/README.md
+++ b/snes-coprocessors/README.md
@@ -27,3 +27,7 @@ Data decompression chip with a compression algorithm tailored to SNES graphical 
 Both of these use a pre-programmed µPD96050 CPU (with different program and data ROMs), with the ST010 clocked at 10 MHz and the ST011 clocked at 15 MHz.
 
 Each of these was only used in 1 game: _F1 ROC II: Race of Champions_ (ST010) and _Hayazashi Nidan Morita Shogi_ (ST011).
+
+### Super FX
+
+Programmable custom-designed RISC-like CPU with hardware to automatically convert plotted bitmap graphics to the SNES bitplane graphics format. Used by 8 released games including _Star Fox_ and _Yoshi's Island_, as well as the (originally) unreleased _Star Fox 2_

--- a/snes-coprocessors/src/lib.rs
+++ b/snes-coprocessors/src/lib.rs
@@ -2,4 +2,5 @@ mod common;
 pub mod cx4;
 pub mod sa1;
 pub mod sdd1;
+pub mod superfx;
 pub mod upd77c25;

--- a/snes-coprocessors/src/superfx.rs
+++ b/snes-coprocessors/src/superfx.rs
@@ -1,0 +1,187 @@
+//! Super FX GSU (Graphics Support Unit), a programmable custom RISC-like CPU
+//!
+//! There were 3 different Super FX chips used: Mario Chip 1, GSU-1, and GSU-2. The only differences
+//! between chips seem to be clock speed and memory capacity.
+//!
+//! Mario Chip 1 runs at 10.74 MHz, GSU-1 and GSU-2 run at 21.47 MHz.
+//!
+//! Mario Chip 1 and GSU-1 apparently only supported up to 1MB of ROM, while GSU-2 supported up
+//! to 2MB of ROM. GSU-2 also supported "backup RAM" and "CPU ROM" but no released cartridges used
+//! these features.
+
+mod gsu;
+
+use crate::common::Rom;
+use crate::superfx::gsu::{BusAccess, GraphicsSupportUnit};
+use bincode::{Decode, Encode};
+use jgenesis_proc_macros::PartialClone;
+use std::mem;
+
+#[derive(Debug, Clone, Encode, Decode, PartialClone)]
+pub struct SuperFx {
+    #[partial_clone(default)]
+    rom: Rom,
+    ram: Box<[u8]>,
+    gsu: GraphicsSupportUnit,
+}
+
+impl SuperFx {
+    #[must_use]
+    pub fn new(rom: Box<[u8]>, ram: Box<[u8]>) -> Self {
+        Self { rom: Rom(rom), ram, gsu: GraphicsSupportUnit::new() }
+    }
+
+    #[inline]
+    #[must_use]
+    pub fn read(&mut self, address: u32) -> Option<u8> {
+        let bank = (address >> 16) & 0xFF;
+        let offset = address & 0xFFFF;
+        match (bank, offset) {
+            (0x00..=0x3F | 0x80..=0xBF, 0x3000..=0x30FF | 0x3300..=0x34FF) => {
+                // GSU I/O ports
+                self.gsu.read_register(address)
+            }
+            (0x00..=0x3F | 0x80..=0xBF, 0x3100..=0x32FF) => {
+                // GSU code cache RAM
+                self.gsu.read_code_cache_ram(address)
+            }
+            (0x00..=0x3F | 0x80..=0xBF, 0x8000..=0xFFFF) => {
+                // ROM, LoROM mapping
+                match (self.gsu.is_running(), self.gsu.rom_access()) {
+                    (false, _) | (true, BusAccess::Snes) => {
+                        let rom_addr = map_lorom_address(address, self.rom.len() as u32);
+                        Some(self.rom[rom_addr as usize])
+                    }
+                    (true, BusAccess::Gsu) => fixed_sfx_interrupt_vector(address),
+                }
+            }
+            (0x40..=0x5F | 0xC0..=0xDF, _) => {
+                // ROM, HiROM mapping
+                match (self.gsu.is_running(), self.gsu.rom_access()) {
+                    (false, _) | (true, BusAccess::Snes) => {
+                        let rom_addr = map_hirom_address(address, self.rom.len() as u32);
+                        Some(self.rom[rom_addr as usize])
+                    }
+                    (true, BusAccess::Gsu) => fixed_sfx_interrupt_vector(address),
+                }
+            }
+            (0x00..=0x3F | 0x80..=0xBF, 0x6000..=0x7FFF) => {
+                // First 8KB of RAM
+                (!self.gsu.is_running() || self.gsu.ram_access() == BusAccess::Snes)
+                    .then(|| self.ram[(address & 0x1FFF) as usize])
+            }
+            (0x70..=0x71 | 0xF0..=0xF1, _) => {
+                // RAM
+                (!self.gsu.is_running() || self.gsu.ram_access() == BusAccess::Snes)
+                    .then(|| self.ram[(address as usize) & (self.ram.len() - 1)])
+            }
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub fn write(&mut self, address: u32, value: u8) {
+        let bank = (address >> 16) & 0xFF;
+        let offset = address & 0xFFFF;
+        match (bank, offset) {
+            (0x00..=0x3F | 0x80..=0xBF, 0x3000..=0x30FF | 0x3300..=0x34FF) => {
+                // GSU I/O ports
+                self.gsu.write_register(address, value);
+            }
+            (0x00..=0x3F | 0x80..=0xBF, 0x3100..=0x32FF) => {
+                // GSU code cache RAM
+                self.gsu.write_code_cache_ram(address, value);
+            }
+            (0x00..=0x3F | 0x80..=0xBF, 0x6000..=0x7FFF) => {
+                // First 8KB of RAM
+                if !self.gsu.is_running() || self.gsu.ram_access() == BusAccess::Snes {
+                    self.ram[(address & 0x1FFF) as usize] = value;
+                }
+            }
+            (0x70..=0x71 | 0xF0..=0xF1, _) => {
+                // RAM
+                if !self.gsu.is_running() || self.gsu.ram_access() == BusAccess::Snes {
+                    self.ram[(address as usize) & (self.ram.len() - 1)] = value;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    #[inline]
+    pub fn tick(&mut self, master_cycles_elapsed: u64) {
+        self.gsu.tick(master_cycles_elapsed, &self.rom, &mut self.ram);
+    }
+
+    #[inline]
+    #[must_use]
+    pub fn irq(&self) -> bool {
+        self.gsu.irq()
+    }
+
+    pub fn reset(&mut self) {
+        self.gsu.reset();
+    }
+
+    #[inline]
+    #[must_use]
+    pub fn sram(&self) -> &[u8] {
+        self.ram.as_ref()
+    }
+
+    #[must_use]
+    pub fn take_rom(&mut self) -> Vec<u8> {
+        mem::take(&mut self.rom.0).into_vec()
+    }
+
+    pub fn set_rom(&mut self, rom: Vec<u8>) {
+        self.rom.0 = rom.into_boxed_slice();
+    }
+}
+
+fn map_lorom_address(address: u32, rom_len: u32) -> u32 {
+    let rom_addr = (address & 0x7FFF) | ((address & 0x7F0000) >> 1);
+    rom_addr & (rom_len - 1)
+}
+
+fn map_hirom_address(address: u32, rom_len: u32) -> u32 {
+    let rom_addr = address & 0x3FFFFF;
+    rom_addr & (rom_len - 1)
+}
+
+const SFX_COP_VECTOR: u16 = 0x0104;
+const SFX_BRK_VECTOR: u16 = 0x0100;
+const SFX_ABORT_VECTOR: u16 = 0x0100;
+const SFX_NMI_VECTOR: u16 = 0x0108;
+const SFX_IRQ_VECTOR: u16 = 0x010C;
+
+fn fixed_sfx_interrupt_vector(address: u32) -> Option<u8> {
+    // If the SNES CPU accesses ROM while the GSU is running and has control of the ROM bus, the
+    // SNES CPU reads fixed values based on the last 4 bits of the address (intended to allow the
+    // SNES to read interrupt vectors while the GSU is running)
+    match address & 0xF {
+        0x4 => Some(SFX_COP_VECTOR as u8),
+        0x5 => Some((SFX_COP_VECTOR >> 8) as u8),
+        0x6 => Some(SFX_BRK_VECTOR as u8),
+        0x7 => Some((SFX_BRK_VECTOR >> 8) as u8),
+        0x8 => Some(SFX_ABORT_VECTOR as u8),
+        0x9 => Some((SFX_ABORT_VECTOR >> 8) as u8),
+        0xA => Some(SFX_NMI_VECTOR as u8),
+        0xB => Some((SFX_NMI_VECTOR >> 8) as u8),
+        0xE => Some(SFX_IRQ_VECTOR as u8),
+        0xF => Some((SFX_IRQ_VECTOR >> 8) as u8),
+        _ => None,
+    }
+}
+
+#[must_use]
+pub fn guess_ram_len(rom: &[u8]) -> usize {
+    // $7FDA == maker code; $33 indicates extended header
+    // $7FBD == expansion RAM size in extended header, as kilobytes as a power of 2
+    // Older Super FX games don't have an extended header, so default to 32KB if the header doesn't
+    // explicitly specify 64KB
+    match (rom[0x7FDA], rom[0x7FBD]) {
+        (0x33, 0x06) => 64 * 1024,
+        _ => 32 * 1024,
+    }
+}

--- a/snes-coprocessors/src/superfx/gsu.rs
+++ b/snes-coprocessors/src/superfx/gsu.rs
@@ -1,0 +1,539 @@
+mod codecache;
+mod instructions;
+
+use crate::superfx::gsu::codecache::CodeCache;
+use crate::superfx::gsu::instructions::PlotState;
+use bincode::{Decode, Encode};
+use jgenesis_common::num::GetBit;
+use jgenesis_proc_macros::EnumDisplay;
+use std::fmt::{Display, Formatter};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Encode, Decode, EnumDisplay)]
+enum MultiplierSpeed {
+    #[default]
+    Standard,
+    High,
+}
+
+impl MultiplierSpeed {
+    fn from_bit(bit: bool) -> Self {
+        if bit { Self::High } else { Self::Standard }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Encode, Decode)]
+enum ClockSpeed {
+    #[default]
+    Slow,
+    Fast,
+}
+
+impl ClockSpeed {
+    fn from_bit(bit: bool) -> Self {
+        if bit { Self::Fast } else { Self::Slow }
+    }
+
+    const fn mclk_divider(self) -> u64 {
+        match self {
+            // mclk/2 = 10.74 MHz
+            Self::Slow => 2,
+            // mclk/1 = 21.47 MHz
+            Self::Fast => 1,
+        }
+    }
+
+    const fn memory_access_cycles(self) -> u8 {
+        match self {
+            Self::Slow => 3,
+            Self::Fast => 5,
+        }
+    }
+
+    const fn rom_buffer_wait_cycles(self) -> u8 {
+        // TODO are these numbers right?
+        match self {
+            Self::Slow => 4,
+            Self::Fast => 7,
+        }
+    }
+}
+
+impl Display for ClockSpeed {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Slow => write!(f, "10.74 MHz"),
+            Self::Fast => write!(f, "21.47 MHz"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Encode, Decode)]
+enum ColorGradientColors {
+    #[default]
+    Four,
+    Sixteen,
+    TwoFiftySix,
+}
+
+impl ColorGradientColors {
+    fn from_byte(byte: u8) -> Self {
+        match byte & 0x03 {
+            0x00 => Self::Four,
+            0x01 => Self::Sixteen,
+            0x02 | 0x03 => Self::TwoFiftySix,
+            _ => unreachable!("value & 0x03 is always <= 0x03"),
+        }
+    }
+
+    const fn tile_size(self) -> u32 {
+        match self {
+            Self::Four => 16,
+            Self::Sixteen => 32,
+            Self::TwoFiftySix => 64,
+        }
+    }
+
+    const fn bitplanes(self) -> u32 {
+        match self {
+            Self::Four => 2,
+            Self::Sixteen => 4,
+            Self::TwoFiftySix => 8,
+        }
+    }
+
+    const fn color_mask(self) -> u8 {
+        match self {
+            Self::Four => 0x03,
+            Self::Sixteen => 0x0F,
+            Self::TwoFiftySix => 0xFF,
+        }
+    }
+}
+
+impl Display for ColorGradientColors {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Four => write!(f, "4-color"),
+            Self::Sixteen => write!(f, "16-color"),
+            Self::TwoFiftySix => write!(f, "256-color"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Encode, Decode)]
+enum ScreenHeight {
+    #[default]
+    Bg128Pixel,
+    Bg160Pixel,
+    Bg192Pixel,
+    ObjMode,
+}
+
+impl ScreenHeight {
+    fn from_byte(byte: u8) -> Self {
+        match (byte.bit(5), byte.bit(2)) {
+            (false, false) => Self::Bg128Pixel,
+            (false, true) => Self::Bg160Pixel,
+            (true, false) => Self::Bg192Pixel,
+            (true, true) => Self::ObjMode,
+        }
+    }
+}
+
+impl Display for ScreenHeight {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Bg128Pixel => write!(f, "128-pixel"),
+            Self::Bg160Pixel => write!(f, "160-pixel"),
+            Self::Bg192Pixel => write!(f, "192-pixel"),
+            Self::ObjMode => write!(f, "OBJ mode"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Encode, Decode)]
+pub enum BusAccess {
+    #[default]
+    Snes,
+    Gsu,
+}
+
+impl BusAccess {
+    fn from_bit(bit: bool) -> Self {
+        if bit { Self::Gsu } else { Self::Snes }
+    }
+}
+
+impl Display for BusAccess {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Snes => write!(f, "SNES"),
+            Self::Gsu => write!(f, "GSU"),
+        }
+    }
+}
+
+const NOP_OPCODE: u8 = 0x01;
+
+#[derive(Debug, Clone, Encode, Decode)]
+struct GsuState {
+    opcode_buffer: u8,
+    rom_buffer: u8,
+    rom_buffer_wait_cycles: u8,
+    ram_buffer_wait_cycles: u8,
+    ram_address_buffer: u16,
+    rom_pointer_changed: bool,
+    ram_buffer_written: bool,
+    just_jumped: bool,
+}
+
+impl GsuState {
+    fn new() -> Self {
+        Self {
+            opcode_buffer: NOP_OPCODE,
+            rom_buffer: 0,
+            rom_buffer_wait_cycles: 0,
+            ram_buffer_wait_cycles: 0,
+            ram_address_buffer: 0,
+            rom_pointer_changed: false,
+            ram_buffer_written: false,
+            just_jumped: false,
+        }
+    }
+}
+
+const VERSION_REGISTER: u8 = 0x04;
+
+#[derive(Debug, Clone, Encode, Decode)]
+pub struct GraphicsSupportUnit {
+    r: [u16; 16],
+    r_latch: u8,
+    pbr: u8,
+    rombr: u8,
+    code_cache: CodeCache,
+    state: GsuState,
+    plot_state: PlotState,
+    zero_flag: bool,
+    carry_flag: bool,
+    sign_flag: bool,
+    overflow_flag: bool,
+    go: bool,
+    alt1: bool,
+    alt2: bool,
+    b: bool,
+    sreg: u8,
+    dreg: u8,
+    irq: bool,
+    irq_enabled: bool,
+    multiplier_speed: MultiplierSpeed,
+    clock_speed: ClockSpeed,
+    screen_base: u32,
+    color: u8,
+    color_gradient: ColorGradientColors,
+    screen_height: ScreenHeight,
+    plot_transparent_pixels: bool,
+    dither_on: bool,
+    por_high_nibble_flag: bool,
+    por_freeze_high_nibble: bool,
+    force_obj_mode: bool,
+    rom_access: BusAccess,
+    ram_access: BusAccess,
+    wait_cycles: u8,
+}
+
+impl GraphicsSupportUnit {
+    pub fn new() -> Self {
+        Self {
+            r: [0; 16],
+            r_latch: 0,
+            pbr: 0,
+            rombr: 0,
+            code_cache: CodeCache::new(),
+            state: GsuState::new(),
+            plot_state: PlotState::new(),
+            zero_flag: false,
+            carry_flag: false,
+            sign_flag: false,
+            overflow_flag: false,
+            go: false,
+            alt1: false,
+            alt2: false,
+            b: false,
+            sreg: 0,
+            dreg: 0,
+            irq: false,
+            irq_enabled: false,
+            multiplier_speed: MultiplierSpeed::Standard,
+            clock_speed: ClockSpeed::Slow,
+            screen_base: 0,
+            color: 0,
+            color_gradient: ColorGradientColors::default(),
+            screen_height: ScreenHeight::default(),
+            plot_transparent_pixels: false,
+            dither_on: false,
+            por_high_nibble_flag: false,
+            por_freeze_high_nibble: false,
+            force_obj_mode: false,
+            rom_access: BusAccess::default(),
+            ram_access: BusAccess::default(),
+            wait_cycles: 0,
+        }
+    }
+
+    pub fn read_register(&mut self, address: u32) -> Option<u8> {
+        log::trace!("GSU register read {:04X}", address & 0xFFFF);
+
+        if self.go {
+            // Only SFR and VCR can be read while the GSU is running
+            return match address & 0x3F {
+                0x30 => Some(self.read_sfr_low()),
+                0x31 => Some(self.read_sfr_high()),
+                0x3B => Some(VERSION_REGISTER),
+                _ => None,
+            };
+        }
+
+        match address & 0x3F {
+            0x00..=0x1F => Some(self.read_r(address)),
+            0x20 | 0x30 => Some(self.read_sfr_low()),
+            0x21 | 0x31 => Some(self.read_sfr_high()),
+            0x24 | 0x34 => Some(self.pbr),
+            0x26 | 0x36 => Some(self.rombr),
+            0x2B | 0x3B => Some(VERSION_REGISTER),
+            0x2E | 0x3E => Some((self.code_cache.cbr() >> 8) as u8),
+            0x2F | 0x3F => Some(self.code_cache.cbr() as u8),
+            _ => Some(0x00),
+        }
+    }
+
+    #[allow(clippy::match_same_arms)]
+    pub fn write_register(&mut self, address: u32, value: u8) {
+        log::trace!("GSU register write {:04X} {value:02X}", address & 0xFFFF);
+
+        if self.go {
+            // Only SFR and SCMR can be written while the GSU is running
+            match address & 0xFFFF {
+                0x3030 => self.write_sfr(value),
+                0x303A => self.write_scmr(value),
+                _ => {}
+            }
+            return;
+        }
+
+        match address & 0xFFFF {
+            0x3000..=0x301F => self.write_r(address, value),
+            0x3030 => self.write_sfr(value),
+            0x3034 => self.write_pbr(value),
+            0x3037 => self.write_cfgr(value),
+            0x3038 => self.write_scbr(value),
+            0x3039 => self.write_clsr(value),
+            0x303A => self.write_scmr(value),
+            _ => {}
+        }
+    }
+
+    pub fn read_code_cache_ram(&self, address: u32) -> Option<u8> {
+        if self.go {
+            return None;
+        }
+
+        let ram_addr = map_snes_code_cache_address(address, self.code_cache.cbr());
+        Some(self.code_cache.read_ram(ram_addr as u16))
+    }
+
+    pub fn write_code_cache_ram(&mut self, address: u32, value: u8) {
+        if self.go {
+            return;
+        }
+
+        let ram_addr = map_snes_code_cache_address(address, self.code_cache.cbr());
+        self.code_cache.write_ram(ram_addr as u16, value);
+    }
+
+    pub fn is_running(&self) -> bool {
+        self.go
+    }
+
+    pub fn rom_access(&self) -> BusAccess {
+        self.rom_access
+    }
+
+    pub fn ram_access(&self) -> BusAccess {
+        self.ram_access
+    }
+
+    pub fn tick(&mut self, master_cycles_elapsed: u64, rom: &[u8], ram: &mut [u8]) {
+        if !self.go {
+            self.wait_cycles = 0;
+            return;
+        }
+
+        let mut gsu_cycles = master_cycles_elapsed / self.clock_speed.mclk_divider();
+        while gsu_cycles >= u64::from(self.wait_cycles) {
+            gsu_cycles -= u64::from(self.wait_cycles);
+            self.wait_cycles = instructions::execute(self, rom, ram);
+
+            // Check if a STOP was executed
+            if !self.go {
+                self.wait_cycles = 0;
+                return;
+            }
+        }
+
+        self.wait_cycles -= gsu_cycles as u8;
+    }
+
+    pub fn irq(&self) -> bool {
+        self.irq_enabled && self.irq
+    }
+
+    pub fn reset(&mut self) {
+        self.go = false;
+        self.code_cache.full_clear();
+        self.irq = false;
+    }
+
+    fn read_r(&self, address: u32) -> u8 {
+        let idx = (address & 0x1F) >> 1;
+        if !address.bit(0) { self.r[idx as usize] as u8 } else { (self.r[idx as usize] >> 8) as u8 }
+    }
+
+    fn read_sfr_low(&self) -> u8 {
+        (u8::from(self.zero_flag) << 1)
+            | (u8::from(self.carry_flag) << 2)
+            | (u8::from(self.sign_flag) << 3)
+            | (u8::from(self.overflow_flag) << 4)
+            | (u8::from(self.go) << 5)
+            | (u8::from(self.state.rom_buffer_wait_cycles != 0) << 6)
+    }
+
+    fn read_sfr_high(&mut self) -> u8 {
+        let value = (u8::from(self.alt1))
+            | (u8::from(self.alt2) << 1)
+            | (u8::from(self.b) << 4)
+            | (u8::from(self.irq) << 7);
+
+        // Reading SFR high byte clears pending IRQ
+        self.irq = false;
+
+        value
+    }
+
+    fn write_r(&mut self, address: u32, value: u8) {
+        // R0-R15: General registers (16x 16-bit)
+        // R14 is always ROM pointer and R15 is always program counter
+
+        // Writing LSB latches the write
+        // Writing MSB writes the register using the latched value + incoming value
+        if !address.bit(0) {
+            self.r_latch = value;
+        } else {
+            let idx = ((address & 0x1F) >> 1) as usize;
+            self.r[idx] = u16::from_le_bytes([self.r_latch, value]);
+            log::trace!("  R{idx}: {:04X}", self.r[idx]);
+        }
+
+        // Writing R15 MSB ($301F) causes the GSU to begin execution
+        if address & 0x1F == 0x1F {
+            self.go = true;
+            self.state.just_jumped = true;
+            log::trace!("  Started GSU execution");
+        }
+    }
+
+    fn write_sfr(&mut self, value: u8) {
+        // SFR: Status/flag register
+        // Bits 1-5 are R/W, rest are read-only
+        self.zero_flag = value.bit(1);
+        self.carry_flag = value.bit(2);
+        self.sign_flag = value.bit(3);
+        self.overflow_flag = value.bit(4);
+
+        let prev_go = self.go;
+        self.go = value.bit(5);
+
+        if !self.go {
+            // Writing GO=0 sets CBR=0 and clears all code cache lines
+            self.code_cache.full_clear();
+        }
+
+        if !prev_go && self.go {
+            self.state.just_jumped = true;
+        }
+
+        log::trace!("  GO: {}", self.go);
+    }
+
+    fn write_pbr(&mut self, value: u8) {
+        self.pbr = value;
+        log::trace!("  PBR: {value:02X}");
+    }
+
+    fn write_cfgr(&mut self, value: u8) {
+        // CFGR: Config register
+        self.multiplier_speed = MultiplierSpeed::from_bit(value.bit(5));
+        self.irq_enabled = !value.bit(7);
+
+        log::trace!("  Multiplier speed: {}", self.multiplier_speed);
+        log::trace!("  GSU IRQ enabled: {}", self.irq_enabled);
+    }
+
+    fn write_clsr(&mut self, value: u8) {
+        // CLSR: Clock select register
+        self.clock_speed = ClockSpeed::from_bit(value.bit(0));
+
+        log::trace!("  Clock speed: {}", self.clock_speed);
+    }
+
+    fn write_scbr(&mut self, value: u8) {
+        // SCBR: Screen base register
+        // value is in 1KB units
+        self.screen_base = u32::from(value) << 10;
+
+        log::trace!("  Screen base: {:05X}", self.screen_base);
+    }
+
+    fn write_scmr(&mut self, value: u8) {
+        // SCMR: Screen mode register
+        self.ram_access = BusAccess::from_bit(value.bit(3));
+        self.rom_access = BusAccess::from_bit(value.bit(4));
+
+        // TODO it doesn't seem like these fields can be altered while the GSU is running?
+        if !self.go {
+            self.color_gradient = ColorGradientColors::from_byte(value);
+            self.screen_height = ScreenHeight::from_byte(value);
+        }
+
+        log::trace!("  ROM bus access: {}", self.rom_access);
+        log::trace!("  RAM bus access: {}", self.ram_access);
+        log::trace!("  Color gradient: {}", self.color_gradient);
+        log::trace!("  Screen height: {}", self.screen_height);
+    }
+}
+
+fn map_snes_code_cache_address(address: u32, cbr: u16) -> u32 {
+    let snes_offset = (address & 0xFFFF) - 0x3100;
+    snes_offset.wrapping_sub((cbr & 0x1FF).into()) & 0x1FF
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn snes_code_cache_mapping() {
+        assert_eq!(0, map_snes_code_cache_address(0x003100, 0));
+        assert_eq!(0x1FF, map_snes_code_cache_address(0x0032FF, 0));
+
+        assert_eq!(0, map_snes_code_cache_address(0xC03100, 0));
+        assert_eq!(0x1FF, map_snes_code_cache_address(0xC032FF, 0));
+
+        assert_eq!(0, map_snes_code_cache_address(0x003250, 0x9150));
+        assert_eq!(0x0AF, map_snes_code_cache_address(0xBF32FF, 0x9150));
+        assert_eq!(0x0B0, map_snes_code_cache_address(0x003100, 0x9150));
+
+        assert_eq!(0, map_snes_code_cache_address(0x003250, 0x9B50));
+        assert_eq!(0x0AF, map_snes_code_cache_address(0xBF32FF, 0x9B50));
+        assert_eq!(0x0B0, map_snes_code_cache_address(0x003100, 0x9B50));
+    }
+}

--- a/snes-coprocessors/src/superfx/gsu/codecache.rs
+++ b/snes-coprocessors/src/superfx/gsu/codecache.rs
@@ -1,0 +1,83 @@
+use bincode::{Decode, Encode};
+use jgenesis_common::num::GetBit;
+
+const CODE_CACHE_RAM_LEN: usize = 512;
+
+type CodeCacheRam = [u8; CODE_CACHE_RAM_LEN];
+
+#[derive(Debug, Clone, Encode, Decode)]
+pub struct CodeCache {
+    ram: Box<CodeCacheRam>,
+    cbr: u16,
+    cached_lines: u32,
+}
+
+impl CodeCache {
+    pub fn new() -> Self {
+        Self {
+            ram: vec![0; CODE_CACHE_RAM_LEN].into_boxed_slice().try_into().unwrap(),
+            cbr: 0,
+            cached_lines: 0,
+        }
+    }
+
+    pub fn pc_is_cacheable(&self, address: u16) -> bool {
+        if self.cbr < 0xFE00 {
+            (self.cbr..self.cbr + 512).contains(&address)
+        } else {
+            address >= self.cbr || address < self.cbr.wrapping_add(512)
+        }
+    }
+
+    pub fn get(&self, address: u16) -> Option<u8> {
+        let cache_addr = address.wrapping_sub(self.cbr);
+        let cache_line_bit = (cache_addr >> 4) as u8;
+        self.cached_lines.bit(cache_line_bit).then_some(self.ram[cache_addr as usize])
+    }
+
+    pub fn set(&mut self, address: u16, value: u8) {
+        let cache_addr = address.wrapping_sub(self.cbr);
+        self.ram[cache_addr as usize] = value;
+
+        if address & 0xF == 0xF {
+            // Cache line is set when the last address of a 16-byte block is written
+            self.set_cache_line(cache_addr);
+        }
+    }
+
+    fn set_cache_line(&mut self, cache_addr: u16) {
+        let cache_line = 1 << (cache_addr >> 4);
+        self.cached_lines |= cache_line;
+    }
+
+    pub fn read_ram(&self, address: u16) -> u8 {
+        self.ram[(address & 0x1FF) as usize]
+    }
+
+    pub fn write_ram(&mut self, address: u16, value: u8) {
+        let cache_addr = address & 0x1FF;
+        self.ram[cache_addr as usize] = value;
+
+        if address & 0xF == 0xF {
+            // Cache line is set when the last address of a 16-byte block is written
+            self.set_cache_line(cache_addr);
+        }
+    }
+
+    pub fn update_cbr(&mut self, cbr: u16) {
+        // Changing CBR via a CACHE or LJMP instruction clears all cache lines
+        self.cbr = cbr;
+        self.cached_lines = 0;
+
+        log::trace!("Set CBR to {cbr:04X}");
+    }
+
+    pub fn full_clear(&mut self) {
+        self.cbr = 0;
+        self.cached_lines = 0;
+    }
+
+    pub fn cbr(&self) -> u16 {
+        self.cbr
+    }
+}

--- a/snes-coprocessors/src/superfx/gsu/instructions.rs
+++ b/snes-coprocessors/src/superfx/gsu/instructions.rs
@@ -1,0 +1,458 @@
+//! Assumptions made to simplify implementation at the cost of timing accuracy (and possibly bus contention accuracy):
+//!   * Every instruction's opcode and operands will be located within the same memory area (code cache / ROM / RAM)
+//!   * If an instruction's opcode is cached, the operands are also cached
+
+mod alu;
+mod disassemble;
+mod flags;
+mod flow;
+mod load;
+mod plot;
+
+use crate::superfx;
+use crate::superfx::gsu::{BusAccess, ClockSpeed, GraphicsSupportUnit};
+
+pub use plot::PlotState;
+
+pub fn execute(gsu: &mut GraphicsSupportUnit, rom: &[u8], ram: &mut [u8]) -> u8 {
+    let memory_type = next_opcode_memory_type(gsu);
+    let opcode = gsu.state.opcode_buffer;
+    if (gsu.rom_access == BusAccess::Snes
+        && (memory_type == MemoryType::Rom || is_rom_access_opcode(opcode)))
+        || (gsu.ram_access == BusAccess::Snes
+            && (memory_type == MemoryType::Ram || is_ram_access_opcode(opcode)))
+    {
+        // GSU is waiting for ROM/RAM access
+        return 1;
+    }
+
+    let mut cycles = 0;
+
+    if gsu.state.just_jumped {
+        gsu.state.just_jumped = false;
+        cycles += fill_cache_to_pc(gsu, gsu.r[15], rom, ram);
+    }
+
+    if memory_type == MemoryType::Rom && gsu.state.rom_buffer_wait_cycles != 0 {
+        cycles += gsu.state.rom_buffer_wait_cycles;
+        gsu.state.rom_buffer_wait_cycles = 0;
+    }
+
+    if memory_type == MemoryType::Ram && gsu.state.ram_buffer_wait_cycles != 0 {
+        cycles += gsu.state.ram_buffer_wait_cycles;
+        gsu.state.ram_buffer_wait_cycles = 0;
+    }
+
+    log::trace!(
+        "Executing opcode {opcode:02X} ({}); PBR={:02X}, R15={:04X}",
+        disassemble::instruction_str(opcode, gsu.alt1, gsu.alt2),
+        gsu.pbr,
+        gsu.r[15],
+    );
+    log::trace!(
+        "  R0={:04X}, R1={:04X}, R2={:04X}, R3={:04X}, R4={:04X}, R5={:04X}, R6={:04X}, R7={:04X}, R8={:04X}, R9={:04X}, R10={:04X}, R11={:04X}, R12={:04X}, R13={:04X}, R14={:04X}, Z={}, C={}, S={}, OV={}",
+        gsu.r[0],
+        gsu.r[1],
+        gsu.r[2],
+        gsu.r[3],
+        gsu.r[4],
+        gsu.r[5],
+        gsu.r[6],
+        gsu.r[7],
+        gsu.r[8],
+        gsu.r[9],
+        gsu.r[10],
+        gsu.r[11],
+        gsu.r[12],
+        gsu.r[13],
+        gsu.r[14],
+        u8::from(gsu.zero_flag),
+        u8::from(gsu.carry_flag),
+        u8::from(gsu.sign_flag),
+        u8::from(gsu.overflow_flag)
+    );
+
+    fetch_opcode(gsu, rom, ram);
+    cycles += execute_opcode(opcode, memory_type, gsu, rom, ram);
+
+    log::trace!("  Cycle count: {cycles}");
+
+    if gsu.state.rom_pointer_changed {
+        gsu.state.rom_pointer_changed = false;
+    } else {
+        gsu.state.rom_buffer_wait_cycles = gsu.state.rom_buffer_wait_cycles.saturating_sub(cycles);
+    }
+
+    if gsu.state.ram_buffer_written {
+        gsu.state.ram_buffer_written = false;
+    } else {
+        gsu.state.ram_buffer_wait_cycles = gsu.state.ram_buffer_wait_cycles.saturating_sub(cycles);
+    }
+
+    gsu.plot_state.tick(cycles);
+
+    cycles
+}
+
+fn is_rom_access_opcode(opcode: u8) -> bool {
+    // GETB/GETBH/GETBL/GETBS ($EF)
+    // GETC/ROMB ($DF)
+    opcode == 0xDF || opcode == 0xEF
+}
+
+fn is_ram_access_opcode(opcode: u8) -> bool {
+    // STB/STW ($3x for x=0-B)
+    // LDB/LDW ($4x for x=0-B)
+    // LM/SM ($Fn for n=0-F)
+    // LMS/SMS ($An for n=0-F)
+    // SBK ($90)
+    matches!(opcode, 0x30..=0x3B | 0x40..=0x4B | 0x90 | 0xA0..=0xAF | 0xF0..=0xFF)
+}
+
+fn u24_address(bank: u8, offset: u16) -> u32 {
+    (u32::from(bank) << 16) | u32::from(offset)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MemoryType {
+    CodeCache,
+    Rom,
+    Ram,
+}
+
+impl MemoryType {
+    fn access_cycles(self, clock_speed: ClockSpeed) -> u8 {
+        match self {
+            Self::CodeCache => 1,
+            Self::Rom | Self::Ram => clock_speed.memory_access_cycles(),
+        }
+    }
+}
+
+fn read_memory(bank: u8, address: u16, rom: &[u8], ram: &[u8]) -> (u8, MemoryType) {
+    match bank {
+        0x00..=0x3F => {
+            // ROM, LoROM mapping (mirrored in $0000-$7FFF and $8000-$FFFF)
+            let rom_addr = superfx::map_lorom_address(u24_address(bank, address), rom.len() as u32);
+            (rom[rom_addr as usize], MemoryType::Rom)
+        }
+        0x40..=0x5F => {
+            // ROM, HiROM mapping
+            let rom_addr = superfx::map_hirom_address(u24_address(bank, address), rom.len() as u32);
+            (rom[rom_addr as usize], MemoryType::Rom)
+        }
+        0x70..=0x71 => {
+            // RAM
+            // Ignore bank since no existing Super FX cartridges have more than 64KB of RAM
+            let ram_addr = (address as usize) & (ram.len() - 1);
+            (ram[ram_addr], MemoryType::Ram)
+        }
+        _ => {
+            log::error!("GSU read unmapped address: ${bank:02X}:{address:04X}");
+            (0, MemoryType::CodeCache)
+        }
+    }
+}
+
+fn fetch_opcode(gsu: &mut GraphicsSupportUnit, rom: &[u8], ram: &[u8]) {
+    if gsu.pbr == 0x00 && gsu.r[15] < 0x0200 {
+        // Executing from code cache
+        let opcode = gsu.code_cache.read_ram(gsu.r[15]);
+        gsu.state.opcode_buffer = opcode;
+        gsu.r[15] = gsu.r[15].wrapping_add(1);
+        return;
+    }
+
+    let is_cacheable = gsu.code_cache.pc_is_cacheable(gsu.r[15]);
+    if is_cacheable {
+        if let Some(opcode) = gsu.code_cache.get(gsu.r[15]) {
+            gsu.state.opcode_buffer = opcode;
+            gsu.r[15] = gsu.r[15].wrapping_add(1);
+            return;
+        }
+    }
+
+    let (opcode, _) = read_memory(gsu.pbr, gsu.r[15], rom, ram);
+    gsu.state.opcode_buffer = opcode;
+
+    log::trace!("  Read opcode {opcode:02X}");
+
+    if is_cacheable {
+        gsu.code_cache.set(gsu.r[15], opcode);
+    }
+
+    gsu.r[15] = gsu.r[15].wrapping_add(1);
+}
+
+fn next_opcode_memory_type(gsu: &GraphicsSupportUnit) -> MemoryType {
+    if gsu.pbr == 0x00 && gsu.r[15] < 0x0200 {
+        return MemoryType::CodeCache;
+    }
+
+    if gsu.code_cache.pc_is_cacheable(gsu.r[15]) && gsu.code_cache.get(gsu.r[15]).is_some() {
+        MemoryType::CodeCache
+    } else {
+        match gsu.pbr {
+            0x00..=0x5F => MemoryType::Rom,
+            0x70..=0x71 => MemoryType::Ram,
+            _ => panic!("invalid GSU bank {:02X}", gsu.pbr),
+        }
+    }
+}
+
+#[must_use]
+fn fill_cache_to_pc(gsu: &mut GraphicsSupportUnit, pc: u16, rom: &[u8], ram: &[u8]) -> u8 {
+    if gsu.pbr == 0x00 && pc < 0x0200 {
+        // Executing in code cache
+        return 0;
+    }
+
+    if !gsu.code_cache.pc_is_cacheable(pc) || gsu.code_cache.get(pc).is_some() {
+        // Not cacheable or already cached
+        return 0;
+    }
+
+    for i in 0..(pc & 0xF) {
+        let cache_addr = (pc & 0xFFF0) | i;
+        let (opcode, _) = read_memory(gsu.pbr, cache_addr, rom, ram);
+        gsu.code_cache.set(cache_addr, opcode);
+    }
+
+    gsu.clock_speed.memory_access_cycles() * (pc & 0xF) as u8
+}
+
+#[must_use]
+fn cache_at_pc(gsu: &mut GraphicsSupportUnit, pc: u16, rom: &[u8], ram: &[u8]) -> u8 {
+    if gsu.pbr == 0x00 && pc < 0x0200 {
+        // Executing in code cache
+        return 0;
+    }
+
+    if !gsu.code_cache.pc_is_cacheable(pc) || gsu.code_cache.get(pc).is_some() {
+        // Not cacheable or already cached
+        return 0;
+    }
+
+    let (opcode, _) = read_memory(gsu.pbr, pc, rom, ram);
+    gsu.code_cache.set(pc, opcode);
+
+    gsu.clock_speed.memory_access_cycles()
+}
+
+#[must_use]
+fn fill_cache_from_pc(gsu: &mut GraphicsSupportUnit, rom: &[u8], ram: &[u8]) -> u8 {
+    if gsu.r[15] & 0xF == 0x0 {
+        // PC is at the beginning of a cache line; no need to fill
+        return 0;
+    }
+
+    if gsu.pbr == 0x00 && gsu.r[15] < 0x0200 {
+        // Executing in code cache
+        return 0;
+    }
+
+    if !gsu.code_cache.pc_is_cacheable(gsu.r[15]) || gsu.code_cache.get(gsu.r[15]).is_some() {
+        // Not cacheable or already cached
+        return 0;
+    }
+
+    for i in (gsu.r[15] & 0xF)..0x10 {
+        let cache_addr = (gsu.r[15] & 0xFFF0) | i;
+        let (opcode, _) = read_memory(gsu.pbr, cache_addr, rom, ram);
+        gsu.code_cache.set(cache_addr, opcode);
+    }
+
+    gsu.clock_speed.memory_access_cycles() * (0x10 - (gsu.r[15] & 0xF) as u8)
+}
+
+fn read_register(gsu: &GraphicsSupportUnit, register: u8) -> u16 {
+    match register {
+        // Subtract 1 from R15 to account for PC increment happening concurrently with execution
+        15 => gsu.r[15].wrapping_sub(1),
+        _ => gsu.r[register as usize],
+    }
+}
+
+#[must_use]
+fn write_register(
+    gsu: &mut GraphicsSupportUnit,
+    register: u8,
+    value: u16,
+    rom: &[u8],
+    ram: &[u8],
+) -> u8 {
+    let cycles = if register == 14 {
+        // Writing to R14 triggers a ROM buffer reload
+        // Note that changing ROMBR does *not* reload the ROM buffer until R14 is written to
+        let (byte, _) = read_memory(gsu.rombr, value, rom, ram);
+        gsu.state.rom_buffer = byte;
+        gsu.state.rom_buffer_wait_cycles = gsu.clock_speed.rom_buffer_wait_cycles();
+        gsu.state.rom_pointer_changed = true;
+
+        0
+    } else if register == 15 {
+        // Writing to R15 fills out the remainder of the current cache line
+        gsu.state.just_jumped = true;
+        fill_cache_from_pc(gsu, rom, ram)
+    } else {
+        0
+    };
+
+    gsu.r[register as usize] = value;
+
+    log::trace!("  Wrote {value:04X} to R{register}");
+
+    cycles
+}
+
+fn clear_prefix_flags(gsu: &mut GraphicsSupportUnit) {
+    gsu.alt1 = false;
+    gsu.alt2 = false;
+    gsu.b = false;
+    gsu.sreg = 0;
+    gsu.dreg = 0;
+}
+
+fn execute_opcode(
+    opcode: u8,
+    memory_type: MemoryType,
+    gsu: &mut GraphicsSupportUnit,
+    rom: &[u8],
+    ram: &mut [u8],
+) -> u8 {
+    match opcode {
+        0x00 => stop(memory_type, gsu),
+        0x01 => nop(memory_type, gsu),
+        0x02 => cache(memory_type, gsu, rom, ram),
+        0x03 => alu::lsr(memory_type, gsu, rom, ram),
+        0x04 => alu::rol(memory_type, gsu, rom, ram),
+        0x05 => flow::bra(memory_type, gsu, rom, ram),
+        0x06 => flow::bge(memory_type, gsu, rom, ram),
+        0x07 => flow::blt(memory_type, gsu, rom, ram),
+        0x08 => flow::bne(memory_type, gsu, rom, ram),
+        0x09 => flow::beq(memory_type, gsu, rom, ram),
+        0x0A => flow::bpl(memory_type, gsu, rom, ram),
+        0x0B => flow::bmi(memory_type, gsu, rom, ram),
+        0x0C => flow::bcc(memory_type, gsu, rom, ram),
+        0x0D => flow::bcs(memory_type, gsu, rom, ram),
+        0x0E => flow::bvc(memory_type, gsu, rom, ram),
+        0x0F => flow::bvs(memory_type, gsu, rom, ram),
+        0x10..=0x1F => flags::to(opcode, memory_type, gsu, rom, ram),
+        0x20..=0x2F => flags::with(opcode, memory_type, gsu),
+        0x30..=0x3B => {
+            if gsu.alt1 {
+                load::stb(opcode, memory_type, gsu, ram)
+            } else {
+                load::stw(opcode, memory_type, gsu, ram)
+            }
+        }
+        0x3C => flow::loop_(memory_type, gsu, rom, ram),
+        0x3D => flags::alt1(memory_type, gsu),
+        0x3E => flags::alt2(memory_type, gsu),
+        0x3F => flags::alt3(memory_type, gsu),
+        0x40..=0x4B => {
+            if gsu.alt1 {
+                load::ldb(opcode, memory_type, gsu, rom, ram)
+            } else {
+                load::ldw(opcode, memory_type, gsu, rom, ram)
+            }
+        }
+        0x4C => {
+            if gsu.alt1 {
+                plot::rpix(memory_type, gsu, rom, ram)
+            } else {
+                plot::plot(memory_type, gsu, ram)
+            }
+        }
+        0x4D => load::swap(memory_type, gsu, rom, ram),
+        0x4E => {
+            if gsu.alt1 {
+                plot::cmode(memory_type, gsu)
+            } else {
+                plot::color(memory_type, gsu)
+            }
+        }
+        0x4F => alu::not(memory_type, gsu, rom, ram),
+        0x50..=0x5F => alu::add(opcode, memory_type, gsu, rom, ram),
+        0x60..=0x6F => alu::sub(opcode, memory_type, gsu, rom, ram),
+        0x70 => load::merge(memory_type, gsu, rom, ram),
+        0x71..=0x7F => alu::and(opcode, memory_type, gsu, rom, ram),
+        0x80..=0x8F => alu::mult(opcode, memory_type, gsu, rom, ram),
+        0x90 => load::sbk(memory_type, gsu, ram),
+        0x91..=0x94 => flow::link(opcode, memory_type, gsu),
+        0x95 => alu::sex(memory_type, gsu, rom, ram),
+        0x96 => alu::asr(memory_type, gsu, rom, ram),
+        0x97 => alu::ror(memory_type, gsu, rom, ram),
+        0x98..=0x9D => {
+            if gsu.alt1 {
+                flow::ljmp(opcode, memory_type, gsu, rom, ram)
+            } else {
+                flow::jmp(opcode, memory_type, gsu, rom, ram)
+            }
+        }
+        0x9E => load::lob(memory_type, gsu, rom, ram),
+        0x9F => alu::fmult(memory_type, gsu, rom, ram),
+        0xA0..=0xAF => match (gsu.alt2, gsu.alt1) {
+            (false, false) => load::ibt(opcode, memory_type, gsu, rom, ram),
+            (_, true) => load::lms(opcode, memory_type, gsu, rom, ram),
+            (true, false) => load::sms(opcode, memory_type, gsu, rom, ram),
+        },
+        0xB0..=0xBF => flags::from(opcode, memory_type, gsu, rom, ram),
+        0xC0 => load::hib(memory_type, gsu, rom, ram),
+        0xC1..=0xCF => alu::or(opcode, memory_type, gsu, rom, ram),
+        0xD0..=0xDE => alu::inc(opcode, memory_type, gsu, rom, ram),
+        0xDF => match (gsu.alt2, gsu.alt1) {
+            (false, _) => plot::getc(memory_type, gsu),
+            (true, false) => {
+                // RAMB; treat as a NOP because no Super FX cartridge has more than 64KB of RAM
+                nop(memory_type, gsu)
+            }
+            (true, true) => load::romb(memory_type, gsu),
+        },
+        0xE0..=0xEE => alu::dec(opcode, memory_type, gsu, rom, ram),
+        0xEF => load::getb(memory_type, gsu, rom, ram),
+        0xF0..=0xFF => match (gsu.alt2, gsu.alt1) {
+            (false, false) => load::iwt(opcode, memory_type, gsu, rom, ram),
+            (_, true) => load::lm(opcode, memory_type, gsu, rom, ram),
+            (true, false) => load::sm(opcode, memory_type, gsu, rom, ram),
+        },
+    }
+}
+
+fn stop(memory_type: MemoryType, gsu: &mut GraphicsSupportUnit) -> u8 {
+    // STOP: Stop the GSU
+    gsu.go = false;
+    gsu.irq = true;
+
+    clear_prefix_flags(gsu);
+    memory_type.access_cycles(gsu.clock_speed)
+}
+
+fn nop(memory_type: MemoryType, gsu: &mut GraphicsSupportUnit) -> u8 {
+    // NOP: No-op
+    clear_prefix_flags(gsu);
+    memory_type.access_cycles(gsu.clock_speed)
+}
+
+fn cache(memory_type: MemoryType, gsu: &mut GraphicsSupportUnit, rom: &[u8], ram: &[u8]) -> u8 {
+    // CACHE: Set cache bank register
+    let cbr = gsu.r[15].wrapping_sub(1) & 0xFFF0;
+    let (updated, cycles) = if cbr != gsu.code_cache.cbr() {
+        gsu.code_cache.update_cbr(cbr);
+
+        let mut cycles = fill_cache_to_pc(gsu, gsu.r[15].wrapping_sub(1), rom, ram);
+        cycles += cache_at_pc(gsu, gsu.r[15].wrapping_sub(1), rom, ram);
+
+        (true, cycles)
+    } else {
+        (false, 0)
+    };
+
+    cycles
+        + match memory_type {
+            MemoryType::CodeCache => 1,
+            MemoryType::Rom | MemoryType::Ram => {
+                memory_type.access_cycles(gsu.clock_speed) + u8::from(updated)
+            }
+        }
+}

--- a/snes-coprocessors/src/superfx/gsu/instructions/alu.rs
+++ b/snes-coprocessors/src/superfx/gsu/instructions/alu.rs
@@ -1,0 +1,365 @@
+use crate::superfx::gsu::instructions::{
+    clear_prefix_flags, read_register, write_register, MemoryType,
+};
+use crate::superfx::gsu::{GraphicsSupportUnit, MultiplierSpeed};
+use jgenesis_common::num::{GetBit, SignBit};
+
+pub(super) fn add(
+    opcode: u8,
+    memory_type: MemoryType,
+    gsu: &mut GraphicsSupportUnit,
+    rom: &[u8],
+    ram: &[u8],
+) -> u8 {
+    // ADD/ADC: Add / Add with carry
+    // ALT1 controls ADD vs. ADC
+    // ALT2 controls register operand vs. immediate operand
+    let operand =
+        if gsu.alt2 { u16::from(opcode & 0x0F) } else { read_register(gsu, opcode & 0x0F) };
+
+    let existing_carry = if gsu.alt1 { u16::from(gsu.carry_flag) } else { 0 };
+
+    let source = read_register(gsu, gsu.sreg);
+    let (partial_sum, carry1) = source.overflowing_add(operand);
+    let (sum, carry2) = partial_sum.overflowing_add(existing_carry);
+    let carry = carry1 || carry2;
+
+    let bit_14_carry = (source & 0x7FFF) + (operand & 0x7FFF) + existing_carry >= 0x8000;
+    let overflow = bit_14_carry != carry;
+
+    gsu.zero_flag = sum == 0;
+    gsu.carry_flag = carry;
+    gsu.sign_flag = sum.sign_bit();
+    gsu.overflow_flag = overflow;
+
+    let cycles = write_register(gsu, gsu.dreg, sum, rom, ram);
+
+    clear_prefix_flags(gsu);
+    cycles + memory_type.access_cycles(gsu.clock_speed)
+}
+
+pub(super) fn sub(
+    opcode: u8,
+    memory_type: MemoryType,
+    gsu: &mut GraphicsSupportUnit,
+    rom: &[u8],
+    ram: &[u8],
+) -> u8 {
+    // SUB/SBC/CMP: Subtract / Subtract with carry / Compare
+    // ALT1 controls SUB vs. SBC/CMP
+    // For SUB, ALT2 controls register operand vs. immediate operand
+    // For SBC/CMP, ALT2 controls SBC vs. CMP
+    let operand = if !gsu.alt1 && gsu.alt2 {
+        u16::from(opcode & 0x0F)
+    } else {
+        read_register(gsu, opcode & 0x0F)
+    };
+
+    let sbc = gsu.alt1 && !gsu.alt2;
+    let existing_borrow = if sbc { u16::from(!gsu.carry_flag) } else { 0 };
+
+    let source = read_register(gsu, gsu.sreg);
+    let (partial_diff, borrow1) = source.overflowing_sub(operand);
+    let (difference, borrow2) = partial_diff.overflowing_sub(existing_borrow);
+    let borrow = borrow1 || borrow2;
+
+    let bit_14_borrow = source & 0x7FFF < (operand & 0x7FFF) + existing_borrow;
+    let overflow = bit_14_borrow != borrow;
+
+    gsu.zero_flag = difference == 0;
+    gsu.carry_flag = !borrow;
+    gsu.sign_flag = difference.sign_bit();
+    gsu.overflow_flag = overflow;
+
+    let mut cycles = 0;
+    if !(gsu.alt1 && gsu.alt2) {
+        // Only write if not CMP
+        cycles = write_register(gsu, gsu.dreg, difference, rom, ram);
+    }
+
+    clear_prefix_flags(gsu);
+    cycles + memory_type.access_cycles(gsu.clock_speed)
+}
+
+pub(super) fn fmult(
+    memory_type: MemoryType,
+    gsu: &mut GraphicsSupportUnit,
+    rom: &[u8],
+    ram: &[u8],
+) -> u8 {
+    // FMULT/LMULT: Fractional signed multiplication / Long signed multiplication
+    // ALT1 controls FMULT vs. LMULT
+    let source: i32 = (read_register(gsu, gsu.sreg) as i16).into();
+    let operand: i32 = (gsu.r[6] as i16).into();
+    let product = source * operand;
+    let high_word = (product >> 16) as u16;
+
+    if gsu.alt1 {
+        // LMULT: Write low word to R4
+        gsu.r[4] = product as u16;
+    }
+
+    // FMULT does not write the result when Dreg is 4
+    // LMULT always writes the result
+    let mut cycles = 0;
+    if gsu.alt1 || gsu.dreg != 4 {
+        cycles = write_register(gsu, gsu.dreg, high_word, rom, ram);
+    }
+
+    gsu.zero_flag = high_word == 0;
+    gsu.carry_flag = product.bit(15);
+    gsu.sign_flag = high_word.sign_bit();
+
+    clear_prefix_flags(gsu);
+    cycles
+        + match (memory_type, gsu.multiplier_speed) {
+            (MemoryType::CodeCache, MultiplierSpeed::Standard) => 8,
+            (MemoryType::CodeCache, MultiplierSpeed::High) => 4,
+            (MemoryType::Rom | MemoryType::Ram, MultiplierSpeed::Standard) => 11,
+            (MemoryType::Rom | MemoryType::Ram, MultiplierSpeed::High) => 7,
+        }
+}
+
+pub(super) fn mult(
+    opcode: u8,
+    memory_type: MemoryType,
+    gsu: &mut GraphicsSupportUnit,
+    rom: &[u8],
+    ram: &[u8],
+) -> u8 {
+    // MULT/UMULT: Signed multiplication / Unsigned multiplication
+    // ALT1 controls MULT vs. UMULT
+    // ALT2 controls register operand vs. immediate operand
+    let operand =
+        if gsu.alt2 { u16::from(opcode & 0x0F) } else { read_register(gsu, opcode & 0x0F) & 0xFF };
+
+    let source = read_register(gsu, gsu.sreg) & 0xFF;
+
+    let product = if gsu.alt1 {
+        // UMULT: Unsigned 8-bit x 8-bit -> 16-bit
+        source * operand
+    } else {
+        // MULT: Signed 8-bit x 8-bit -> 16-bit
+        (i16::from(source as i8) * i16::from(operand as i8)) as u16
+    };
+
+    let cycles = write_register(gsu, gsu.dreg, product, rom, ram);
+
+    gsu.zero_flag = product == 0;
+    gsu.sign_flag = product.sign_bit();
+
+    clear_prefix_flags(gsu);
+    // TODO ROM/RAM should take more cycles at 21.47 MHz?
+    cycles
+        + match (memory_type, gsu.multiplier_speed) {
+            (MemoryType::CodeCache, MultiplierSpeed::Standard) => 2,
+            (MemoryType::CodeCache, MultiplierSpeed::High) => 1,
+            (MemoryType::Rom | MemoryType::Ram, MultiplierSpeed::Standard) => 5,
+            (MemoryType::Rom | MemoryType::Ram, MultiplierSpeed::High) => 3,
+        }
+}
+
+pub(super) fn inc(
+    opcode: u8,
+    memory_type: MemoryType,
+    gsu: &mut GraphicsSupportUnit,
+    rom: &[u8],
+    ram: &[u8],
+) -> u8 {
+    // INC Rn: Increment register
+    let register = opcode & 0x0F;
+    let incremented = gsu.r[register as usize].wrapping_add(1);
+    let cycles = write_register(gsu, register, incremented, rom, ram);
+
+    gsu.zero_flag = incremented == 0;
+    gsu.sign_flag = incremented.sign_bit();
+
+    clear_prefix_flags(gsu);
+    cycles + memory_type.access_cycles(gsu.clock_speed)
+}
+
+pub(super) fn dec(
+    opcode: u8,
+    memory_type: MemoryType,
+    gsu: &mut GraphicsSupportUnit,
+    rom: &[u8],
+    ram: &[u8],
+) -> u8 {
+    // DEC Rn: Decrement register
+    let register = opcode & 0x0F;
+    let decremented = gsu.r[register as usize].wrapping_sub(1);
+    let cycles = write_register(gsu, register, decremented, rom, ram);
+
+    gsu.zero_flag = decremented == 0;
+    gsu.sign_flag = decremented.sign_bit();
+
+    clear_prefix_flags(gsu);
+    cycles + memory_type.access_cycles(gsu.clock_speed)
+}
+
+pub(super) fn and(
+    opcode: u8,
+    memory_type: MemoryType,
+    gsu: &mut GraphicsSupportUnit,
+    rom: &[u8],
+    ram: &[u8],
+) -> u8 {
+    // AND/BIC: And / And with complement
+    // ALT1 controls AND vs. BIC
+    // ALT2 controls register operand vs. immediate operand
+    let operand =
+        if gsu.alt2 { u16::from(opcode & 0x0F) } else { read_register(gsu, opcode & 0x0F) };
+
+    let source = read_register(gsu, gsu.sreg);
+    let result = if gsu.alt1 { source & !operand } else { source & operand };
+
+    let cycles = write_register(gsu, gsu.dreg, result, rom, ram);
+
+    gsu.zero_flag = result == 0;
+    gsu.sign_flag = result.sign_bit();
+
+    clear_prefix_flags(gsu);
+    cycles + memory_type.access_cycles(gsu.clock_speed)
+}
+
+pub(super) fn or(
+    opcode: u8,
+    memory_type: MemoryType,
+    gsu: &mut GraphicsSupportUnit,
+    rom: &[u8],
+    ram: &[u8],
+) -> u8 {
+    // OR/XOR: Or / Exclusive or
+    // ALT1 controls OR vs. XOR
+    // ALT2 controls register operand vs. immediate operand
+    let operand =
+        if gsu.alt2 { u16::from(opcode & 0x0F) } else { read_register(gsu, opcode & 0x0F) };
+
+    let source = read_register(gsu, gsu.sreg);
+    let result = if gsu.alt1 { source ^ operand } else { source | operand };
+
+    let cycles = write_register(gsu, gsu.dreg, result, rom, ram);
+
+    gsu.zero_flag = result == 0;
+    gsu.sign_flag = result.sign_bit();
+
+    clear_prefix_flags(gsu);
+    cycles + memory_type.access_cycles(gsu.clock_speed)
+}
+
+pub(super) fn not(
+    memory_type: MemoryType,
+    gsu: &mut GraphicsSupportUnit,
+    rom: &[u8],
+    ram: &[u8],
+) -> u8 {
+    // NOT: Bitwise not
+    let source = read_register(gsu, gsu.sreg);
+    let inverted = !source;
+    let cycles = write_register(gsu, gsu.dreg, inverted, rom, ram);
+
+    gsu.zero_flag = inverted == 0;
+    gsu.sign_flag = inverted.sign_bit();
+
+    clear_prefix_flags(gsu);
+    cycles + memory_type.access_cycles(gsu.clock_speed)
+}
+
+pub(super) fn asr(
+    memory_type: MemoryType,
+    gsu: &mut GraphicsSupportUnit,
+    rom: &[u8],
+    ram: &[u8],
+) -> u8 {
+    // ASR/DIV2: Arithmetic shift right / Divide by 2
+    // ALT1 controls ASR vs. DIV2
+    let source = read_register(gsu, gsu.sreg);
+
+    // DIV2 is equivalent to ASR unless Sreg == -1, in which case DIV2 produces 0 and ASR produces -1
+    let shifted =
+        if gsu.alt1 && source == u16::MAX { 0 } else { (source >> 1) | (source & 0x8000) };
+
+    let cycles = write_register(gsu, gsu.dreg, shifted, rom, ram);
+
+    gsu.zero_flag = shifted == 0;
+    gsu.carry_flag = source.bit(0);
+    gsu.sign_flag = shifted.sign_bit();
+
+    clear_prefix_flags(gsu);
+    cycles + memory_type.access_cycles(gsu.clock_speed)
+}
+
+pub(super) fn lsr(
+    memory_type: MemoryType,
+    gsu: &mut GraphicsSupportUnit,
+    rom: &[u8],
+    ram: &[u8],
+) -> u8 {
+    // LSR: Logical shift right
+    let source = read_register(gsu, gsu.sreg);
+    let shifted = source >> 1;
+    let cycles = write_register(gsu, gsu.dreg, shifted, rom, ram);
+
+    gsu.zero_flag = shifted == 0;
+    gsu.carry_flag = source.bit(0);
+    gsu.sign_flag = false;
+
+    clear_prefix_flags(gsu);
+    cycles + memory_type.access_cycles(gsu.clock_speed)
+}
+
+pub(super) fn rol(
+    memory_type: MemoryType,
+    gsu: &mut GraphicsSupportUnit,
+    rom: &[u8],
+    ram: &[u8],
+) -> u8 {
+    // ROL: Rotate left
+    let source = read_register(gsu, gsu.sreg);
+    let rotated = (source << 1) | u16::from(gsu.carry_flag);
+    let cycles = write_register(gsu, gsu.dreg, rotated, rom, ram);
+
+    gsu.zero_flag = rotated == 0;
+    gsu.carry_flag = source.sign_bit();
+    gsu.sign_flag = rotated.sign_bit();
+
+    clear_prefix_flags(gsu);
+    cycles + memory_type.access_cycles(gsu.clock_speed)
+}
+
+pub(super) fn ror(
+    memory_type: MemoryType,
+    gsu: &mut GraphicsSupportUnit,
+    rom: &[u8],
+    ram: &[u8],
+) -> u8 {
+    // ROR: Rotate right
+    let source = read_register(gsu, gsu.sreg);
+    let rotated = (source >> 1) | (u16::from(gsu.carry_flag) << 15);
+    let cycles = write_register(gsu, gsu.dreg, rotated, rom, ram);
+
+    gsu.zero_flag = rotated == 0;
+    gsu.carry_flag = source.bit(0);
+    gsu.sign_flag = rotated.sign_bit();
+
+    clear_prefix_flags(gsu);
+    cycles + memory_type.access_cycles(gsu.clock_speed)
+}
+
+pub(super) fn sex(
+    memory_type: MemoryType,
+    gsu: &mut GraphicsSupportUnit,
+    rom: &[u8],
+    ram: &[u8],
+) -> u8 {
+    // SEX: Sign extend
+    let source = read_register(gsu, gsu.sreg);
+    let extended = (source as i8) as u16;
+    let cycles = write_register(gsu, gsu.dreg, extended, rom, ram);
+
+    gsu.zero_flag = extended == 0;
+    gsu.sign_flag = extended.sign_bit();
+
+    clear_prefix_flags(gsu);
+    cycles + memory_type.access_cycles(gsu.clock_speed)
+}

--- a/snes-coprocessors/src/superfx/gsu/instructions/disassemble.rs
+++ b/snes-coprocessors/src/superfx/gsu/instructions/disassemble.rs
@@ -1,0 +1,138 @@
+pub fn instruction_str(opcode: u8, alt1: bool, alt2: bool) -> String {
+    match opcode {
+        0x00 => "STOP".into(),
+        0x01 => "NOP".into(),
+        0x02 => "CACHE".into(),
+        0x03 => "LSR".into(),
+        0x04 => "ROL".into(),
+        0x05 => "BRA e".into(),
+        0x06 => "BGE e".into(),
+        0x07 => "BLT e".into(),
+        0x08 => "BNE e".into(),
+        0x09 => "BEQ e".into(),
+        0x0A => "BPL e".into(),
+        0x0B => "BMI e".into(),
+        0x0C => "BCC e".into(),
+        0x0D => "BCS e".into(),
+        0x0E => "BVC e".into(),
+        0x0F => "BVS e".into(),
+        0x10..=0x1F => format!("TO R{}", opcode & 0x0F),
+        0x20..=0x2F => format!("WITH R{}", opcode & 0x0F),
+        0x30..=0x3B => {
+            if alt1 {
+                format!("STB (R{})", opcode & 0x0F)
+            } else {
+                format!("STW (R{})", opcode & 0x0F)
+            }
+        }
+        0x3C => "LOOP".into(),
+        0x3D => "ALT1".into(),
+        0x3E => "ALT2".into(),
+        0x3F => "ALT3".into(),
+        0x40..=0x4B => {
+            if alt1 {
+                format!("LDB (R{})", opcode & 0x0F)
+            } else {
+                format!("LDW (R{})", opcode & 0x0F)
+            }
+        }
+        0x4C => {
+            if alt1 {
+                "RPIX".into()
+            } else {
+                "PLOT".into()
+            }
+        }
+        0x4D => "SWAP".into(),
+        0x4E => {
+            if alt1 {
+                "CMODE".into()
+            } else {
+                "COLOR".into()
+            }
+        }
+        0x4F => "NOT".into(),
+        0x50..=0x5F => match (alt2, alt1) {
+            (false, false) => format!("ADD R{}", opcode & 0x0F),
+            (false, true) => format!("ADC R{}", opcode & 0x0F),
+            (true, false) => format!("ADD #{}", opcode & 0x0F),
+            (true, true) => format!("ADC #{}", opcode & 0x0F),
+        },
+        0x60..=0x6F => match (alt2, alt1) {
+            (false, false) => format!("SUB R{}", opcode & 0x0F),
+            (false, true) => format!("SBC R{}", opcode & 0x0F),
+            (true, false) => format!("SUB #{}", opcode & 0x0F),
+            (true, true) => format!("CMP R{}", opcode & 0x0F),
+        },
+        0x70 => "MERGE".into(),
+        0x71..=0x7F => match (alt2, alt1) {
+            (false, false) => format!("AND R{}", opcode & 0x0F),
+            (false, true) => format!("BIC R{}", opcode & 0x0F),
+            (true, false) => format!("AND #{}", opcode & 0x0F),
+            (true, true) => format!("BIC #{}", opcode & 0x0F),
+        },
+        0x80..=0x8F => match (alt2, alt1) {
+            (false, false) => format!("MULT R{}", opcode & 0x0F),
+            (false, true) => format!("UMULT R{}", opcode & 0x0F),
+            (true, false) => format!("MULT #{}", opcode & 0x0F),
+            (true, true) => format!("UMULT #{}", opcode & 0x0F),
+        },
+        0x90 => "SBK".into(),
+        0x91..=0x94 => format!("LINK #{}", opcode & 0x0F),
+        0x95 => "SEX".into(),
+        0x96 => {
+            if alt1 {
+                "DIV2".into()
+            } else {
+                "ASR".into()
+            }
+        }
+        0x97 => "ROR".into(),
+        0x98..=0x9D => {
+            if alt1 {
+                format!("LJMP R{}", opcode & 0x0F)
+            } else {
+                format!("JMP R{}", opcode & 0x0F)
+            }
+        }
+        0x9E => "LOB".into(),
+        0x9F => {
+            if alt1 {
+                "LMULT".into()
+            } else {
+                "FMULT".into()
+            }
+        }
+        0xA0..=0xAF => match (alt2, alt1) {
+            (false, false) => format!("IBT R{}, #pp", opcode & 0x0F),
+            (_, true) => format!("LMS R{}, (yy)", opcode & 0x0F),
+            (true, false) => format!("SMS (yy), R{}", opcode & 0x0F),
+        },
+        0xB0..=0xBF => format!("FROM R{}", opcode & 0x0F),
+        0xC0 => "HIB".into(),
+        0xC1..=0xCF => match (alt2, alt1) {
+            (false, false) => format!("OR R{}", opcode & 0x0F),
+            (false, true) => format!("XOR R{}", opcode & 0x0F),
+            (true, false) => format!("OR #{}", opcode & 0x0F),
+            (true, true) => format!("XOR #{}", opcode & 0x0F),
+        },
+        0xD0..=0xDE => format!("INC R{}", opcode & 0x0F),
+        0xDF => match (alt2, alt1) {
+            (false, _) => "GETC".into(),
+            (true, false) => "RAMB".into(),
+            (true, true) => "ROMB".into(),
+        },
+        0xE0..=0xEE => format!("DEC R{}", opcode & 0x0F),
+        0xEF => match (alt2, alt1) {
+            (false, false) => "GETB".into(),
+            (false, true) => "GETBH".into(),
+            (true, false) => "GETBL".into(),
+            (true, true) => "GETBS".into(),
+        },
+        0xF0..=0xFF => match (alt2, alt1) {
+            (false, false) => format!("IWT R{}, #xx", opcode & 0x0F),
+            (_, true) => format!("LM R{}, (xx)", opcode & 0x0F),
+            (true, false) => format!("SM (xx), R{}", opcode & 0x0F),
+        },
+    }
+}

--- a/snes-coprocessors/src/superfx/gsu/instructions/flags.rs
+++ b/snes-coprocessors/src/superfx/gsu/instructions/flags.rs
@@ -1,0 +1,86 @@
+use crate::superfx::gsu::instructions::{
+    clear_prefix_flags, read_register, write_register, MemoryType,
+};
+use crate::superfx::gsu::GraphicsSupportUnit;
+use jgenesis_common::num::{GetBit, SignBit};
+
+pub(super) fn from(
+    opcode: u8,
+    memory_type: MemoryType,
+    gsu: &mut GraphicsSupportUnit,
+    rom: &[u8],
+    ram: &[u8],
+) -> u8 {
+    // FROM: Set source register
+    // If B flag is set, this executes a MOVE that also sets flags (MOVES)
+    let cycles = if !gsu.b {
+        gsu.sreg = opcode & 0x0F;
+        0
+    } else {
+        let register = opcode & 0x0F;
+        let value = read_register(gsu, register);
+        let cycles = write_register(gsu, gsu.dreg, value, rom, ram);
+
+        gsu.zero_flag = value == 0;
+        gsu.overflow_flag = value.bit(7);
+        gsu.sign_flag = value.sign_bit();
+
+        clear_prefix_flags(gsu);
+        cycles
+    };
+
+    cycles + memory_type.access_cycles(gsu.clock_speed)
+}
+
+pub(super) fn to(
+    opcode: u8,
+    memory_type: MemoryType,
+    gsu: &mut GraphicsSupportUnit,
+    rom: &[u8],
+    ram: &[u8],
+) -> u8 {
+    // TO: Set destination register
+    // If B flag is set, this executes a MOVE
+    let cycles = if !gsu.b {
+        gsu.dreg = opcode & 0x0F;
+        0
+    } else {
+        let register = opcode & 0xF;
+        let value = read_register(gsu, gsu.sreg);
+        let cycles = write_register(gsu, register, value, rom, ram);
+
+        clear_prefix_flags(gsu);
+        cycles
+    };
+
+    cycles + memory_type.access_cycles(gsu.clock_speed)
+}
+
+pub(super) fn with(opcode: u8, memory_type: MemoryType, gsu: &mut GraphicsSupportUnit) -> u8 {
+    // WITH: Set source and destination registers
+    let register = opcode & 0x0F;
+    gsu.sreg = register;
+    gsu.dreg = register;
+    gsu.b = true;
+
+    memory_type.access_cycles(gsu.clock_speed)
+}
+
+pub(super) fn alt1(memory_type: MemoryType, gsu: &mut GraphicsSupportUnit) -> u8 {
+    // ALT1: Set ALT1 flag (modifies instructions)
+    gsu.alt1 = true;
+    memory_type.access_cycles(gsu.clock_speed)
+}
+
+pub(super) fn alt2(memory_type: MemoryType, gsu: &mut GraphicsSupportUnit) -> u8 {
+    // ALT2: Set ALT2 flag (modifies instructions)
+    gsu.alt2 = true;
+    memory_type.access_cycles(gsu.clock_speed)
+}
+
+pub(super) fn alt3(memory_type: MemoryType, gsu: &mut GraphicsSupportUnit) -> u8 {
+    // ALT3: Set both ALT1 and ALT2 flags (modifies instructions)
+    gsu.alt1 = true;
+    gsu.alt2 = true;
+    memory_type.access_cycles(gsu.clock_speed)
+}

--- a/snes-coprocessors/src/superfx/gsu/instructions/flow.rs
+++ b/snes-coprocessors/src/superfx/gsu/instructions/flow.rs
@@ -1,0 +1,110 @@
+use crate::superfx::gsu::instructions::{
+    clear_prefix_flags, fetch_opcode, fill_cache_from_pc, fill_cache_to_pc, read_register,
+    MemoryType,
+};
+use crate::superfx::gsu::GraphicsSupportUnit;
+use jgenesis_common::num::SignBit;
+
+pub(super) fn link(opcode: u8, memory_type: MemoryType, gsu: &mut GraphicsSupportUnit) -> u8 {
+    // LINK #n: Link return address
+    let n = opcode & 0x0F;
+    gsu.r[11] = gsu.r[15].wrapping_add(n.into()).wrapping_sub(1);
+
+    clear_prefix_flags(gsu);
+    memory_type.access_cycles(gsu.clock_speed)
+}
+
+macro_rules! impl_branch {
+    ($name:ident $(, $flag:ident $(^ $other:ident)? == $value:expr)?) => {
+        pub(super) fn $name(memory_type: MemoryType, gsu: &mut GraphicsSupportUnit, rom: &[u8], ram: &[u8]) -> u8 {
+            let e = gsu.state.opcode_buffer as i8;
+            fetch_opcode(gsu, rom, ram);
+
+            $(
+                if gsu.$flag $(^ gsu.$other)? != $value {
+                    return 2 * memory_type.access_cycles(gsu.clock_speed);
+                }
+            )?
+
+            let cycles = fill_cache_from_pc(gsu, rom, ram);
+
+            gsu.r[15] = gsu.r[15].wrapping_add(e as u16).wrapping_sub(1);
+            gsu.state.just_jumped = true;
+
+            cycles + 2 * memory_type.access_cycles(gsu.clock_speed)
+        }
+    }
+}
+
+// Branch instructions
+impl_branch!(bra);
+impl_branch!(bge, sign_flag ^ overflow_flag == false);
+impl_branch!(blt, sign_flag ^ overflow_flag == true);
+impl_branch!(bne, zero_flag == false);
+impl_branch!(beq, zero_flag == true);
+impl_branch!(bpl, sign_flag == false);
+impl_branch!(bmi, sign_flag == true);
+impl_branch!(bcc, carry_flag == false);
+impl_branch!(bcs, carry_flag == true);
+impl_branch!(bvc, overflow_flag == false);
+impl_branch!(bvs, overflow_flag == true);
+
+pub(super) fn jmp(
+    opcode: u8,
+    memory_type: MemoryType,
+    gsu: &mut GraphicsSupportUnit,
+    rom: &[u8],
+    ram: &[u8],
+) -> u8 {
+    // JMP Rn: Jump
+    let cycles = fill_cache_from_pc(gsu, rom, ram);
+
+    gsu.r[15] = gsu.r[(opcode & 0x0F) as usize];
+    gsu.state.just_jumped = true;
+
+    cycles + memory_type.access_cycles(gsu.clock_speed)
+}
+
+pub(super) fn ljmp(
+    opcode: u8,
+    memory_type: MemoryType,
+    gsu: &mut GraphicsSupportUnit,
+    rom: &[u8],
+    ram: &[u8],
+) -> u8 {
+    // LJMP Rn: Long jump
+    gsu.r[15] = read_register(gsu, gsu.sreg);
+    gsu.pbr = gsu.r[(opcode & 0x0F) as usize] as u8;
+
+    let cbr = gsu.r[15] & 0xFFF0;
+    gsu.code_cache.update_cbr(cbr);
+    let cycles = fill_cache_to_pc(gsu, gsu.r[15], rom, ram);
+
+    clear_prefix_flags(gsu);
+    cycles + memory_type.access_cycles(gsu.clock_speed)
+}
+
+pub(super) fn loop_(
+    memory_type: MemoryType,
+    gsu: &mut GraphicsSupportUnit,
+    rom: &[u8],
+    ram: &[u8],
+) -> u8 {
+    // LOOP: Loop
+    gsu.r[12] = gsu.r[12].wrapping_sub(1);
+    gsu.zero_flag = gsu.r[12] == 0;
+    gsu.sign_flag = gsu.r[12].sign_bit();
+
+    let cycles = if !gsu.zero_flag {
+        let cycles = fill_cache_from_pc(gsu, rom, ram);
+        gsu.r[15] = gsu.r[13];
+        gsu.state.just_jumped = true;
+
+        cycles
+    } else {
+        0
+    };
+
+    clear_prefix_flags(gsu);
+    cycles + memory_type.access_cycles(gsu.clock_speed)
+}

--- a/snes-coprocessors/src/superfx/gsu/instructions/load.rs
+++ b/snes-coprocessors/src/superfx/gsu/instructions/load.rs
@@ -1,0 +1,441 @@
+use crate::superfx::gsu::instructions::{
+    clear_prefix_flags, fetch_opcode, read_register, write_register, MemoryType,
+};
+use crate::superfx::gsu::GraphicsSupportUnit;
+use jgenesis_common::num::SignBit;
+
+pub(super) fn ldb(
+    opcode: u8,
+    memory_type: MemoryType,
+    gsu: &mut GraphicsSupportUnit,
+    rom: &[u8],
+    ram: &[u8],
+) -> u8 {
+    // LDB (Rm): Load byte from RAM
+    let m = opcode & 0x0F;
+    let ram_addr = (gsu.r[m as usize] as usize) & (ram.len() - 1);
+    let value = ram[ram_addr];
+
+    let mut cycles = write_register(gsu, gsu.dreg, value.into(), rom, ram);
+
+    cycles += gsu.state.ram_buffer_wait_cycles;
+    gsu.state.ram_buffer_wait_cycles = 0;
+    gsu.state.ram_address_buffer = ram_addr as u16;
+
+    log::trace!("Loaded {value:02X} from RAM[{ram_addr:X}]");
+
+    clear_prefix_flags(gsu);
+    cycles
+        + match memory_type {
+            MemoryType::CodeCache => 6,
+            MemoryType::Rom => 11,
+            MemoryType::Ram => 13,
+        }
+}
+
+pub(super) fn ldw(
+    opcode: u8,
+    memory_type: MemoryType,
+    gsu: &mut GraphicsSupportUnit,
+    rom: &[u8],
+    ram: &[u8],
+) -> u8 {
+    // LDW (Rm): Load word from RAM
+    let m = opcode & 0x0F;
+    let ram_addr = (gsu.r[m as usize] as usize) & (ram.len() - 1);
+    let value_lsb = ram[ram_addr];
+    let value_msb = ram[ram_addr ^ 1];
+    let value = u16::from_le_bytes([value_lsb, value_msb]);
+
+    let mut cycles = write_register(gsu, gsu.dreg, value, rom, ram);
+
+    log::trace!("Loaded {value:04X} from RAM[{ram_addr:X}]");
+
+    cycles += gsu.state.ram_buffer_wait_cycles;
+    gsu.state.ram_buffer_wait_cycles = 0;
+    gsu.state.ram_address_buffer = ram_addr as u16;
+
+    clear_prefix_flags(gsu);
+    cycles
+        + match memory_type {
+            MemoryType::CodeCache => 7,
+            MemoryType::Rom => 10,
+            MemoryType::Ram => 12,
+        }
+}
+
+pub(super) fn stb(
+    opcode: u8,
+    memory_type: MemoryType,
+    gsu: &mut GraphicsSupportUnit,
+    ram: &mut [u8],
+) -> u8 {
+    // STB (Rm): Store byte in RAM
+    let byte = read_register(gsu, gsu.sreg) as u8;
+
+    let register = opcode & 0x0F;
+    let ram_addr = (gsu.r[register as usize] as usize) & (ram.len() - 1);
+    ram[ram_addr] = byte;
+
+    log::trace!("Stored {byte:02X} at RAM[{ram_addr:X}]");
+
+    let cycles = gsu.state.ram_buffer_wait_cycles;
+    gsu.state.ram_buffer_wait_cycles = gsu.clock_speed.memory_access_cycles();
+    gsu.state.ram_buffer_written = true;
+
+    clear_prefix_flags(gsu);
+    cycles
+        + match memory_type {
+            MemoryType::CodeCache => 1,
+            MemoryType::Rom => 3,
+            MemoryType::Ram => 7,
+        }
+}
+
+pub(super) fn stw(
+    opcode: u8,
+    memory_type: MemoryType,
+    gsu: &mut GraphicsSupportUnit,
+    ram: &mut [u8],
+) -> u8 {
+    // STW (Rm): Store word in RAM
+    let source = read_register(gsu, gsu.sreg);
+    let [source_lsb, source_msb] = source.to_le_bytes();
+
+    let register = opcode & 0x0F;
+    let ram_addr = (gsu.r[register as usize] as usize) & (ram.len() - 1);
+    ram[ram_addr] = source_lsb;
+    ram[ram_addr ^ 1] = source_msb;
+
+    log::trace!("Stored {source:04X} at RAM[{ram_addr:X}]");
+
+    let cycles = gsu.state.ram_buffer_wait_cycles;
+    gsu.state.ram_buffer_wait_cycles = 2 * gsu.clock_speed.memory_access_cycles();
+    gsu.state.ram_buffer_written = true;
+
+    clear_prefix_flags(gsu);
+    cycles
+        + match memory_type {
+            MemoryType::CodeCache => 1,
+            MemoryType::Rom => 3,
+            MemoryType::Ram => 7,
+        }
+}
+
+pub(super) fn ibt(
+    opcode: u8,
+    memory_type: MemoryType,
+    gsu: &mut GraphicsSupportUnit,
+    rom: &[u8],
+    ram: &[u8],
+) -> u8 {
+    // IBT Rn, #pp: Load immediate byte (sign extended to 16 bits)
+    let pp = gsu.state.opcode_buffer;
+    fetch_opcode(gsu, rom, ram);
+
+    let register = opcode & 0xF;
+    let value = (pp as i8) as u16;
+    let write_cycles = write_register(gsu, register, value, rom, ram);
+
+    clear_prefix_flags(gsu);
+    write_cycles + 2 * memory_type.access_cycles(gsu.clock_speed)
+}
+
+pub(super) fn iwt(
+    opcode: u8,
+    memory_type: MemoryType,
+    gsu: &mut GraphicsSupportUnit,
+    rom: &[u8],
+    ram: &[u8],
+) -> u8 {
+    // IWT Rn, #xx: Load immediate word
+    let lsb = gsu.state.opcode_buffer;
+    fetch_opcode(gsu, rom, ram);
+    let msb = gsu.state.opcode_buffer;
+    fetch_opcode(gsu, rom, ram);
+
+    let value = u16::from_le_bytes([lsb, msb]);
+    let register = opcode & 0x0F;
+    let cycles = write_register(gsu, register, value, rom, ram);
+
+    clear_prefix_flags(gsu);
+    cycles + 3 * memory_type.access_cycles(gsu.clock_speed)
+}
+
+pub(super) fn lm(
+    opcode: u8,
+    memory_type: MemoryType,
+    gsu: &mut GraphicsSupportUnit,
+    rom: &[u8],
+    ram: &[u8],
+) -> u8 {
+    // LM Rn, (xx): Load from RAM
+    let ram_addr_lsb = gsu.state.opcode_buffer;
+    fetch_opcode(gsu, rom, ram);
+    let ram_addr_msb = gsu.state.opcode_buffer;
+    fetch_opcode(gsu, rom, ram);
+
+    let ram_addr = (u16::from_le_bytes([ram_addr_lsb, ram_addr_msb]) as usize) & (ram.len() - 1);
+    let value_lsb = ram[ram_addr];
+    let value_msb = ram[ram_addr ^ 1];
+    let value = u16::from_le_bytes([value_lsb, value_msb]);
+
+    log::trace!("Loaded {value:04X} from RAM[{ram_addr:X}");
+
+    let register = opcode & 0x0F;
+    let mut cycles = write_register(gsu, register, value, rom, ram);
+
+    cycles += gsu.state.ram_buffer_wait_cycles;
+    gsu.state.ram_buffer_wait_cycles = 0;
+    gsu.state.ram_address_buffer = ram_addr as u16;
+
+    clear_prefix_flags(gsu);
+    cycles
+        + match memory_type {
+            MemoryType::CodeCache => 10,
+            MemoryType::Rom => 17,
+            MemoryType::Ram => 18,
+        }
+}
+
+pub(super) fn lms(
+    opcode: u8,
+    memory_type: MemoryType,
+    gsu: &mut GraphicsSupportUnit,
+    rom: &[u8],
+    ram: &[u8],
+) -> u8 {
+    // LMS Rn, (yy): Load from RAM short
+    let kk = gsu.state.opcode_buffer;
+    fetch_opcode(gsu, rom, ram);
+
+    let yy = u16::from(kk) << 1;
+    let ram_addr = (yy as usize) & (ram.len() - 1);
+    let lsb = ram[ram_addr];
+    let msb = ram[ram_addr ^ 1];
+    let value = u16::from_le_bytes([lsb, msb]);
+
+    let register = opcode & 0x0F;
+    let mut cycles = write_register(gsu, register, value, rom, ram);
+
+    log::trace!("Loaded {value:04X} from RAM[{ram_addr:X}]");
+
+    cycles += gsu.state.ram_buffer_wait_cycles;
+    gsu.state.ram_buffer_wait_cycles = 0;
+    gsu.state.ram_address_buffer = ram_addr as u16;
+
+    clear_prefix_flags(gsu);
+    cycles
+        + match memory_type {
+            MemoryType::CodeCache => 10,
+            MemoryType::Rom | MemoryType::Ram => 17,
+        }
+}
+
+pub(super) fn sm(
+    opcode: u8,
+    memory_type: MemoryType,
+    gsu: &mut GraphicsSupportUnit,
+    rom: &[u8],
+    ram: &mut [u8],
+) -> u8 {
+    // SM (xx), Rn: Store in RAM
+    let ram_addr_lsb = gsu.state.opcode_buffer;
+    fetch_opcode(gsu, rom, ram);
+    let ram_addr_msb = gsu.state.opcode_buffer;
+    fetch_opcode(gsu, rom, ram);
+
+    let ram_addr = (u16::from_le_bytes([ram_addr_lsb, ram_addr_msb]) as usize) & (ram.len() - 1);
+
+    let register = opcode & 0x0F;
+    let [value_lsb, value_msb] = read_register(gsu, register).to_le_bytes();
+    ram[ram_addr] = value_lsb;
+    ram[ram_addr ^ 1] = value_msb;
+
+    log::trace!("Stored {value_msb:02X}{value_lsb:02X} at RAM[{ram_addr:X}]");
+
+    let cycles = gsu.state.ram_buffer_wait_cycles;
+    gsu.state.ram_buffer_wait_cycles = 2 * gsu.clock_speed.memory_access_cycles();
+    gsu.state.ram_buffer_written = true;
+
+    clear_prefix_flags(gsu);
+    cycles
+        + match memory_type {
+            MemoryType::CodeCache => 3,
+            MemoryType::Rom => 9,
+            MemoryType::Ram => 13,
+        }
+}
+
+pub(super) fn sms(
+    opcode: u8,
+    memory_type: MemoryType,
+    gsu: &mut GraphicsSupportUnit,
+    rom: &[u8],
+    ram: &mut [u8],
+) -> u8 {
+    // SMS (yy), Rn: Store in RAM short
+    let kk = gsu.state.opcode_buffer;
+    fetch_opcode(gsu, rom, ram);
+
+    let yy = u16::from(kk) << 1;
+    let ram_addr = (yy as usize) & (ram.len() - 1);
+
+    let register = opcode & 0x0F;
+    let [lsb, msb] = read_register(gsu, register).to_le_bytes();
+    ram[ram_addr] = lsb;
+    ram[ram_addr ^ 1] = msb;
+
+    log::trace!("Stored {msb:02X}{lsb:02X} at RAM[{ram_addr:X}]");
+
+    let cycles = gsu.state.ram_buffer_wait_cycles;
+    gsu.state.ram_buffer_wait_cycles = 2 * gsu.clock_speed.memory_access_cycles();
+    gsu.state.ram_buffer_written = true;
+
+    clear_prefix_flags(gsu);
+    cycles
+        + match memory_type {
+            MemoryType::CodeCache => 3,
+            MemoryType::Rom => 9,
+            MemoryType::Ram => 13,
+        }
+}
+
+pub(super) fn sbk(memory_type: MemoryType, gsu: &mut GraphicsSupportUnit, ram: &mut [u8]) -> u8 {
+    // SBK: Store word in RAM at last address used
+    let [source_lsb, source_msb] = read_register(gsu, gsu.sreg).to_le_bytes();
+    let ram_addr = gsu.state.ram_address_buffer;
+    ram[ram_addr as usize] = source_lsb;
+    ram[(ram_addr ^ 1) as usize] = source_msb;
+
+    log::trace!("Stored {source_msb:02X}{source_lsb:02X} at RAM[{ram_addr:X}]");
+
+    let cycles = gsu.state.ram_buffer_wait_cycles;
+    gsu.state.ram_buffer_wait_cycles = 2 * gsu.clock_speed.memory_access_cycles();
+    gsu.state.ram_buffer_written = true;
+
+    clear_prefix_flags(gsu);
+    cycles
+        + match memory_type {
+            MemoryType::CodeCache => 1,
+            MemoryType::Rom => 3,
+            MemoryType::Ram => 7,
+        }
+}
+
+pub(super) fn romb(memory_type: MemoryType, gsu: &mut GraphicsSupportUnit) -> u8 {
+    // ROMB: Set ROM bank register
+    gsu.rombr = read_register(gsu, gsu.sreg) as u8;
+
+    log::trace!("  Set ROMBR to {:02X}", gsu.rombr);
+
+    let cycles = gsu.state.rom_buffer_wait_cycles;
+    gsu.state.rom_buffer_wait_cycles = 0;
+
+    clear_prefix_flags(gsu);
+    cycles + memory_type.access_cycles(gsu.clock_speed)
+}
+
+pub(super) fn getb(
+    memory_type: MemoryType,
+    gsu: &mut GraphicsSupportUnit,
+    rom: &[u8],
+    ram: &[u8],
+) -> u8 {
+    // GETB/GETBH/GETBL/GETBS: Get byte from ROM
+    // !ALT1 && !ALT2: GETB (Write to LSB, zero extend)
+    // ALT1 && !ALT2: GETBH (Write to MSB, leave LSB unchanged)
+    // !ALT1 && ALT2: GETBL (Write to LSB, leave MSB unchanged)
+    // ALT1 && ALT2: GETBS (Write to LSB, sign extend)
+    let byte = gsu.state.rom_buffer;
+    let source = read_register(gsu, gsu.sreg);
+
+    let value = match (gsu.alt1, gsu.alt2) {
+        (false, false) => u16::from(byte),
+        (true, false) => u16::from_le_bytes([source as u8, byte]),
+        (false, true) => u16::from_le_bytes([byte, (source >> 8) as u8]),
+        (true, true) => byte as i8 as u16,
+    };
+
+    let mut cycles = write_register(gsu, gsu.dreg, value, rom, ram);
+
+    cycles += gsu.state.rom_buffer_wait_cycles;
+    gsu.state.rom_buffer_wait_cycles = 0;
+
+    clear_prefix_flags(gsu);
+    cycles + memory_type.access_cycles(gsu.clock_speed)
+}
+
+pub(super) fn hib(
+    memory_type: MemoryType,
+    gsu: &mut GraphicsSupportUnit,
+    rom: &[u8],
+    ram: &[u8],
+) -> u8 {
+    // HIB: High byte of register
+    let source = read_register(gsu, gsu.sreg);
+    let source_msb = (source >> 8) as u8;
+    let cycles = write_register(gsu, gsu.dreg, source_msb.into(), rom, ram);
+
+    gsu.zero_flag = source_msb == 0;
+    gsu.sign_flag = source_msb.sign_bit();
+
+    clear_prefix_flags(gsu);
+    cycles + memory_type.access_cycles(gsu.clock_speed)
+}
+
+pub(super) fn lob(
+    memory_type: MemoryType,
+    gsu: &mut GraphicsSupportUnit,
+    rom: &[u8],
+    ram: &[u8],
+) -> u8 {
+    // LOB: Low byte of register
+    let source = read_register(gsu, gsu.sreg);
+    let source_lsb = source as u8;
+    let cycles = write_register(gsu, gsu.dreg, source_lsb.into(), rom, ram);
+
+    gsu.zero_flag = source_lsb == 0;
+    gsu.sign_flag = source_lsb.sign_bit();
+
+    clear_prefix_flags(gsu);
+    cycles + memory_type.access_cycles(gsu.clock_speed)
+}
+
+pub(super) fn swap(
+    memory_type: MemoryType,
+    gsu: &mut GraphicsSupportUnit,
+    rom: &[u8],
+    ram: &[u8],
+) -> u8 {
+    // SWAP: Swap bytes
+    let source = read_register(gsu, gsu.sreg);
+    let swapped = source.swap_bytes();
+    let cycles = write_register(gsu, gsu.dreg, swapped, rom, ram);
+
+    gsu.zero_flag = swapped == 0;
+    gsu.sign_flag = swapped.sign_bit();
+
+    clear_prefix_flags(gsu);
+    cycles + memory_type.access_cycles(gsu.clock_speed)
+}
+
+pub(super) fn merge(
+    memory_type: MemoryType,
+    gsu: &mut GraphicsSupportUnit,
+    rom: &[u8],
+    ram: &[u8],
+) -> u8 {
+    // MERGE: Merge high bytes
+    // Dreg.H = R7.H, Dreg.L = R8.H
+    let merged = (gsu.r[7] & 0xFF00) | (gsu.r[8] >> 8);
+    let cycles = write_register(gsu, gsu.dreg, merged, rom, ram);
+
+    gsu.zero_flag = merged & 0xF0F0 != 0;
+    gsu.carry_flag = merged & 0xE0E0 != 0;
+    gsu.sign_flag = merged & 0x8080 != 0;
+    gsu.overflow_flag = merged & 0xC0C0 != 0;
+
+    clear_prefix_flags(gsu);
+    cycles + memory_type.access_cycles(gsu.clock_speed)
+}

--- a/snes-coprocessors/src/superfx/gsu/instructions/plot.rs
+++ b/snes-coprocessors/src/superfx/gsu/instructions/plot.rs
@@ -1,0 +1,294 @@
+use crate::superfx::gsu::instructions::{
+    clear_prefix_flags, read_register, write_register, MemoryType,
+};
+use crate::superfx::gsu::{GraphicsSupportUnit, ScreenHeight};
+use bincode::{Decode, Encode};
+use jgenesis_common::num::{GetBit, SignBit};
+use std::cmp;
+
+#[derive(Debug, Clone, Encode, Decode)]
+struct PixelBuffer {
+    pixels: [u8; 8],
+    valid_bits: u8,
+}
+
+impl PixelBuffer {
+    fn new() -> Self {
+        Self { pixels: [0; 8], valid_bits: 0 }
+    }
+
+    fn write_pixel(&mut self, i: u8, color: u8) {
+        self.pixels[i as usize] = color;
+        self.valid_bits |= 1 << i;
+    }
+
+    fn is_valid(&self, i: u8) -> bool {
+        self.valid_bits.bit(i)
+    }
+
+    fn any_valid(&self) -> bool {
+        self.valid_bits != 0
+    }
+
+    fn all_valid(&self) -> bool {
+        self.valid_bits == 0xFF
+    }
+
+    fn clear_valid(&mut self) {
+        self.valid_bits = 0;
+    }
+}
+
+#[derive(Debug, Clone, Encode, Decode)]
+pub struct PlotState {
+    pixel_buffer: PixelBuffer,
+    // The secondary pixel buffer is not explicitly stored; implementation writes values to RAM
+    // immediately when primary buffer is flushed
+    last_coarse_x: u8,
+    last_y: u8,
+    flush_cycles_remaining: u8,
+    just_flushed: bool,
+}
+
+impl PlotState {
+    pub fn new() -> Self {
+        Self {
+            pixel_buffer: PixelBuffer::new(),
+            last_coarse_x: 0,
+            last_y: 0,
+            flush_cycles_remaining: 0,
+            just_flushed: false,
+        }
+    }
+
+    pub fn tick(&mut self, gsu_cycles: u8) {
+        if self.just_flushed {
+            self.just_flushed = false;
+        } else {
+            self.flush_cycles_remaining = self.flush_cycles_remaining.saturating_sub(gsu_cycles);
+        }
+    }
+}
+
+pub(super) fn cmode(memory_type: MemoryType, gsu: &mut GraphicsSupportUnit) -> u8 {
+    // CMODE: Set POR (plot option register)
+    let source = read_register(gsu, gsu.sreg);
+
+    gsu.plot_transparent_pixels = source.bit(0);
+    gsu.dither_on = source.bit(1);
+    gsu.por_high_nibble_flag = source.bit(2);
+    gsu.por_freeze_high_nibble = source.bit(3);
+    gsu.force_obj_mode = source.bit(4);
+
+    log::trace!("Plot transparent pixels: {}", gsu.plot_transparent_pixels);
+    log::trace!("Dithering on: {}", gsu.dither_on);
+    log::trace!("High nibble only in color writes: {}", gsu.por_high_nibble_flag);
+    log::trace!("Freeze color high nibble: {}", gsu.por_freeze_high_nibble);
+    log::trace!("Force OBJ mode: {}", gsu.force_obj_mode);
+
+    clear_prefix_flags(gsu);
+    memory_type.access_cycles(gsu.clock_speed)
+}
+
+pub(super) fn color(memory_type: MemoryType, gsu: &mut GraphicsSupportUnit) -> u8 {
+    // COLOR: Set color register
+    let source = read_register(gsu, gsu.sreg);
+    gsu.color = mask_color(source as u8, gsu);
+
+    clear_prefix_flags(gsu);
+    memory_type.access_cycles(gsu.clock_speed)
+}
+
+pub(super) fn getc(memory_type: MemoryType, gsu: &mut GraphicsSupportUnit) -> u8 {
+    // GETC: Get byte from ROM into color register
+    let byte = gsu.state.rom_buffer;
+    gsu.color = mask_color(byte, gsu);
+
+    let cycles = gsu.state.rom_buffer_wait_cycles;
+    gsu.state.rom_buffer_wait_cycles = 0;
+
+    clear_prefix_flags(gsu);
+    cycles + memory_type.access_cycles(gsu.clock_speed)
+}
+
+fn mask_color(mut new_color: u8, gsu: &GraphicsSupportUnit) -> u8 {
+    if gsu.por_high_nibble_flag {
+        // Replace low nibble with a copy of high nibble
+        new_color = (new_color & 0xF0) | (new_color >> 4);
+    }
+
+    if gsu.por_freeze_high_nibble {
+        // Copy high nibble from existing color register
+        new_color = (new_color & 0x0F) | (gsu.color & 0xF0);
+    }
+
+    new_color
+}
+
+pub(super) fn plot(memory_type: MemoryType, gsu: &mut GraphicsSupportUnit, ram: &mut [u8]) -> u8 {
+    // PLOT: Plot a pixel to the primary pixel buffer
+    let x = gsu.r[1] as u8;
+    let y = gsu.r[2] as u8;
+
+    let mut cycles = 0;
+
+    let coarse_x = x & !0x07;
+    if (coarse_x != gsu.plot_state.last_coarse_x || y != gsu.plot_state.last_y)
+        && gsu.plot_state.pixel_buffer.any_valid()
+    {
+        cycles += flush_pixel_buffer(gsu, ram);
+    }
+
+    gsu.plot_state.last_coarse_x = coarse_x;
+    gsu.plot_state.last_y = y;
+
+    let color = if gsu.dither_on && (x.bit(0) ^ y.bit(0)) { gsu.color >> 4 } else { gsu.color };
+    let is_transparent = if gsu.por_freeze_high_nibble {
+        // If high nibble is frozen, transparency check only looks at the lowest 2/4 bits even in
+        // 256-color mode
+        color & 0x0F & gsu.color_gradient.color_mask() == 0
+    } else {
+        color & gsu.color_gradient.color_mask() == 0
+    };
+
+    if gsu.plot_transparent_pixels || !is_transparent {
+        let i = x & 0x07;
+        gsu.plot_state.pixel_buffer.write_pixel(i, color);
+
+        if gsu.plot_state.pixel_buffer.all_valid() {
+            cycles += flush_pixel_buffer(gsu, ram);
+        }
+    }
+
+    gsu.r[1] = gsu.r[1].wrapping_add(1);
+
+    log::trace!("PLOT: x={x}, y={y}, color={color:02X}");
+
+    clear_prefix_flags(gsu);
+    cmp::max(memory_type.access_cycles(gsu.clock_speed), cycles)
+}
+
+pub(super) fn rpix(
+    memory_type: MemoryType,
+    gsu: &mut GraphicsSupportUnit,
+    rom: &[u8],
+    ram: &mut [u8],
+) -> u8 {
+    // RPIX: Read a pixel from RAM and flush both pixel buffers
+    let bitplanes = gsu.color_gradient.bitplanes();
+    let mut cycles =
+        bitplanes as u8 * memory_type.access_cycles(gsu.clock_speed) - bitplanes as u8 / 2;
+    if gsu.plot_state.pixel_buffer.any_valid() {
+        cycles += flush_pixel_buffer(gsu, ram);
+    }
+
+    cycles += gsu.plot_state.flush_cycles_remaining;
+    gsu.plot_state.flush_cycles_remaining = 0;
+
+    let x = gsu.r[1] as u8;
+    let y = gsu.r[2] as u8;
+
+    let tile_addr = compute_tile_addr(gsu, x, y, ram.len());
+    let tile_size = gsu.color_gradient.tile_size();
+    let tile_data = &ram[tile_addr..tile_addr + tile_size as usize];
+
+    let row = y & 0x07;
+    let line_base_addr: u32 = (row * 0x02).into();
+
+    let pixel_idx = x & 0x07;
+    let bitplane_idx = 7 - pixel_idx;
+
+    let mut color = 0;
+    for plane in (0..bitplanes).step_by(2) {
+        let plane_addr = (line_base_addr + 8 * plane) as usize;
+
+        color |= u8::from(tile_data[plane_addr].bit(bitplane_idx)) << plane;
+        color |= u8::from(tile_data[plane_addr + 1].bit(bitplane_idx)) << (plane + 1);
+    }
+
+    cycles += write_register(gsu, gsu.dreg, color.into(), rom, ram);
+
+    gsu.zero_flag = color == 0;
+    gsu.sign_flag = color.sign_bit();
+
+    clear_prefix_flags(gsu);
+    cycles
+}
+
+#[must_use]
+fn flush_pixel_buffer(gsu: &mut GraphicsSupportUnit, ram: &mut [u8]) -> u8 {
+    let x = gsu.plot_state.last_coarse_x;
+    let y = gsu.plot_state.last_y;
+
+    let tile_addr = compute_tile_addr(gsu, x, y, ram.len());
+    let tile_size = gsu.color_gradient.tile_size();
+
+    let tile_data = &mut ram[tile_addr..tile_addr + tile_size as usize];
+
+    let row = y & 0x07;
+    let line_base_addr: u32 = (row * 0x02).into();
+
+    log::trace!(
+        "  Flushing pixel buffer; base={:05X}, x={x}, y={y}, tile_addr={tile_addr:04X}, line_addr={line_base_addr:02X}",
+        gsu.screen_base
+    );
+
+    // Convert row of pixels from bitmap format to SNES bitplane format, only overwriting pixels that
+    // have the valid flag set in the pixel buffer
+    let bitplanes = gsu.color_gradient.bitplanes();
+    for pixel_idx in 0..8 {
+        if !gsu.plot_state.pixel_buffer.is_valid(pixel_idx) {
+            continue;
+        }
+
+        let shift = 7 - pixel_idx;
+        let color = gsu.plot_state.pixel_buffer.pixels[pixel_idx as usize];
+
+        for plane in (0..bitplanes).step_by(2) {
+            let plane_addr = (line_base_addr + 8 * plane) as usize;
+
+            tile_data[plane_addr] = (tile_data[plane_addr] & !(1 << shift))
+                | (u8::from(color.bit(plane as u8)) << shift);
+            tile_data[plane_addr + 1] = (tile_data[plane_addr + 1] & !(1 << shift))
+                | (u8::from(color.bit(plane as u8 + 1)) << shift);
+        }
+    }
+
+    let cycles = gsu.plot_state.flush_cycles_remaining;
+
+    let mut flush_cycles_required = gsu.clock_speed.memory_access_cycles() * bitplanes as u8;
+    if !gsu.plot_state.pixel_buffer.all_valid() {
+        // If not all 8 bit-pend flags are set, the chip needs to perform a read before each write
+        flush_cycles_required *= 2;
+    }
+
+    gsu.plot_state.pixel_buffer.clear_valid();
+    gsu.plot_state.flush_cycles_remaining = flush_cycles_required;
+    gsu.plot_state.just_flushed = true;
+
+    cycles
+}
+
+fn compute_tile_addr(gsu: &GraphicsSupportUnit, x: u8, y: u8, ram_len: usize) -> usize {
+    let tile_x: u16 = (x / 8).into();
+    let tile_y: u16 = (y / 8).into();
+
+    let screen_height = if gsu.force_obj_mode { ScreenHeight::ObjMode } else { gsu.screen_height };
+
+    let tile_number = match screen_height {
+        ScreenHeight::Bg128Pixel => tile_x * 0x10 + tile_y,
+        ScreenHeight::Bg160Pixel => tile_x * 0x14 + tile_y,
+        ScreenHeight::Bg192Pixel => tile_x * 0x18 + tile_y,
+        ScreenHeight::ObjMode => {
+            let grid_offset = (u16::from(y.bit(7)) << 9) | (u16::from(x.bit(7)) << 8);
+            let grid_x = tile_x & 0x0F;
+            let grid_y = tile_y & 0x0F;
+            grid_offset + grid_y * 0x10 + grid_x
+        }
+    };
+    let tile_number: u32 = tile_number.into();
+
+    let tile_size = gsu.color_gradient.tile_size();
+    let tile_addr = gsu.screen_base + tile_number * tile_size;
+    (tile_addr as usize) & (ram_len - 1)
+}

--- a/snes-core/src/api.rs
+++ b/snes-core/src/api.rs
@@ -324,15 +324,17 @@ impl Resettable for SnesEmulator {
     fn soft_reset(&mut self) {
         log::info!("Soft resetting");
 
-        self.main_cpu.reset(&mut new_bus!(self));
-        self.cpu_registers.reset();
-        self.ppu.reset();
-        self.apu.reset();
-
+        // Reset memory before CPU because some coprocessors (Super FX) block access to interrupt
+        // vectors while the coprocessor is running
         self.memory.reset();
         self.memory.write_wram_port_address_low(0);
         self.memory.write_wram_port_address_mid(0);
         self.memory.write_wram_port_address_high(0);
+
+        self.main_cpu.reset(&mut new_bus!(self));
+        self.cpu_registers.reset();
+        self.ppu.reset();
+        self.apu.reset();
     }
 
     fn hard_reset(&mut self) {

--- a/snes-core/src/memory.rs
+++ b/snes-core/src/memory.rs
@@ -12,6 +12,7 @@ use jgenesis_common::frontend::TimingMode;
 use jgenesis_common::num::GetBit;
 use jgenesis_proc_macros::PartialClone;
 use std::array;
+use std::num::NonZeroU64;
 
 const MAIN_RAM_LEN: usize = 128 * 1024;
 
@@ -52,12 +53,14 @@ impl Memory {
         initial_sram: Option<Vec<u8>>,
         coprocessor_roms: &CoprocessorRoms,
         forced_timing_mode: Option<TimingMode>,
+        gsu_overclock_factor: NonZeroU64,
     ) -> LoadResult<Self> {
         let cartridge = Cartridge::create(
             rom.into_boxed_slice(),
             initial_sram,
             coprocessor_roms,
             forced_timing_mode,
+            gsu_overclock_factor,
         )?;
 
         Ok(Self {
@@ -183,6 +186,10 @@ impl Memory {
     // Called when GPDMA completes (all channels done)
     pub fn notify_dma_end(&mut self) {
         self.cartridge.notify_dma_end();
+    }
+
+    pub fn update_gsu_overclock_factor(&mut self, overclock_factor: NonZeroU64) {
+        self.cartridge.update_gsu_overclock_factor(overclock_factor);
     }
 }
 

--- a/snes-core/src/ppu/debug.rs
+++ b/snes-core/src/ppu/debug.rs
@@ -3,9 +3,8 @@ use jgenesis_common::frontend::Color;
 
 impl Ppu {
     pub fn debug_cram(&self, out: &mut [Color]) {
-        let brightness = self.registers.brightness;
         for (out_color, &snes_color) in out.iter_mut().zip(self.cgram.iter()) {
-            *out_color = convert_snes_color(snes_color, brightness);
+            *out_color = convert_snes_color(snes_color, 15);
         }
     }
 }


### PR DESCRIPTION
The Super FX contains a custom-designed RISC-like CPU, known in earlier versions as the MARIO Chip (Mathematical, Argonaut, Rotation, & Input/Output) and in later versions as the GSU (Graphics Support Unit).

In addition to supporting fast arithmetic and multiplication operations, the GSU has a set of plotting instructions that allow it to plot graphics in a bitmap format while the chip automatically converts the bitmap graphics to SNES bitplane format. Once a plotting operation is complete, the SNES CPU can copy the rendered graphics directly into VRAM (e.g. via DMA).

This plotting capability enables _significantly_ faster graphical transformations than are possible when working with raw bitplane graphics. _Star Fox_ uses this capability to draw 3D graphics using a software renderer, while _Yoshi's Island_ uses it for all sorts of graphical effects beyond what Mode 7 supports (e.g. sprite scaling and rotation).

There were 3 different versions of the Super FX used in released games:
* MARIO Chip: Max clock speed 10.74 MHz, supports up to 1MB of ROM
* GSU-1: Max clock speed 21.47 MHz, supports up to 1MB of ROM
* GSU-2: Max clock speed 21.47 MHz, supports up to 2MB of ROM
  * The GSU-2 also had connections for additional ROM and RAM that the SNES CPU could access while the GSU was running, but no released games used this capacity

The Super FX was used in 8 released games:
* _Star Fox_ (MARIO Chip)
* _Dirt Racer_ (GSU-1)
* _Dirt Trax FX_ (GSU-1)
* _Stunt Race FX_ (GSU-1)
* _Vortex_ (GSU-1)
* _Doom_ (GSU-2)
* _Winter Gold_ (GSU-2)
* _Yoshi's Island_ (GSU-2)

Super FX was also used in the originally unreleased  _Star Fox 2_, which likely would have used GSU-2 had it been released on cartridge.

![Screenshot from 2023-11-20 02-45-52](https://github.com/jsgroth/jgenesis/assets/1137683/56ba6cf5-1276-4182-bbd7-f9f82d4b6ea8)

![Screenshot from 2023-11-20 02-47-53](https://github.com/jsgroth/jgenesis/assets/1137683/fd2da726-977c-449c-a149-cefd51787dd4)
