### PR TITLE
Add support for the SNES Super Scope

### DIFF
--- a/backend/snes-core/src/api.rs
+++ b/backend/snes-core/src/api.rs
@@ -279,6 +279,11 @@ impl EmulatorTrait for SnesEmulator {
         // Copy WRIO from CPU to PPU for possible H/V counter latching
         self.ppu.update_wrio(self.cpu_registers.wrio_register());
 
+        // Possibly latch H/V counter from the controller (e.g. Super Scope)
+        if let Some((h, v)) = self.cpu_registers.controller_hv_latch() {
+            self.ppu.update_controller_hv_latch(h, v, master_cycles_elapsed);
+        }
+
         let prev_scanline_mclk = self.ppu.scanline_master_cycles();
         let mut tick_effect = TickEffect::None;
         if self.ppu.tick(master_cycles_elapsed) == PpuTickEffect::FrameComplete {

--- a/backend/snes-core/src/input.rs
+++ b/backend/snes-core/src/input.rs
@@ -33,7 +33,7 @@ impl SnesJoypadState {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Encode, Decode)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Encode, Decode)]
 pub struct SuperScopeState {
     pub fire: bool,
     pub cursor: bool,
@@ -43,6 +43,12 @@ pub struct SuperScopeState {
     // X should be in the range 0..=255 and Y should be in the range 0..=223 (or 238 if in 239-line mode); other values
     // will be treated as offscreen
     pub position: Option<(u16, u16)>,
+}
+
+impl Default for SuperScopeState {
+    fn default() -> Self {
+        Self { fire: false, cursor: false, pause: false, turbo: true, position: None }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Encode, Decode)]

--- a/backend/snes-core/src/input.rs
+++ b/backend/snes-core/src/input.rs
@@ -31,8 +31,41 @@ impl SnesJoypadState {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct SuperScopeState {
+    pub fire: bool,
+    pub cursor: bool,
+    pub pause: bool,
+    pub turbo: bool,
+    // X/Y position in SNES pixels starting from the top-left corner, or None if position is offscreen
+    // X should be in the range 0..=255 and Y should be in the range 0..=223 (or 238 if in 239-line mode); other values
+    // will be treated as offscreen
+    pub position: Option<(u16, u16)>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SnesInputDevice {
+    Controller(SnesJoypadState),
+    SuperScope(SuperScopeState),
+}
+
+impl Default for SnesInputDevice {
+    fn default() -> Self {
+        Self::Controller(SnesJoypadState::default())
+    }
+}
+
+impl SnesInputDevice {
+    pub(crate) fn to_register_word(self) -> u16 {
+        match self {
+            Self::Controller(joypad_state) => joypad_state.to_register_word(),
+            Self::SuperScope(_) => todo!("super scope to register word"),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct SnesInputs {
     pub p1: SnesJoypadState,
-    pub p2: SnesJoypadState,
+    pub p2: SnesInputDevice,
 }

--- a/backend/snes-core/src/input.rs
+++ b/backend/snes-core/src/input.rs
@@ -1,4 +1,6 @@
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+use bincode::{Decode, Encode};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Encode, Decode)]
 pub struct SnesJoypadState {
     pub up: bool,
     pub left: bool,
@@ -31,7 +33,7 @@ impl SnesJoypadState {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Encode, Decode)]
 pub struct SuperScopeState {
     pub fire: bool,
     pub cursor: bool,
@@ -43,7 +45,7 @@ pub struct SuperScopeState {
     pub position: Option<(u16, u16)>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Encode, Decode)]
 pub enum SnesInputDevice {
     Controller(SnesJoypadState),
     SuperScope(SuperScopeState),
@@ -55,16 +57,7 @@ impl Default for SnesInputDevice {
     }
 }
 
-impl SnesInputDevice {
-    pub(crate) fn to_register_word(self) -> u16 {
-        match self {
-            Self::Controller(joypad_state) => joypad_state.to_register_word(),
-            Self::SuperScope(_) => todo!("super scope to register word"),
-        }
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Default, Encode, Decode)]
 pub struct SnesInputs {
     pub p1: SnesJoypadState,
     pub p2: SnesInputDevice,

--- a/backend/snes-core/src/memory/inputs.rs
+++ b/backend/snes-core/src/memory/inputs.rs
@@ -1,0 +1,191 @@
+use crate::input::{SnesInputDevice, SnesInputs, SnesJoypadState, SuperScopeState};
+use bincode::{Decode, Encode};
+use jgenesis_common::num::GetBit;
+use std::mem;
+
+const AUTO_JOYPAD_DURATION_MCLK: u64 = 4224;
+
+#[derive(Debug, Clone, Copy, Encode, Decode)]
+struct SuperScopeRegister {
+    fire: bool,
+    cursor: bool,
+    pause: bool,
+    turbo: bool,
+    offscreen: bool,
+    position: Option<(u16, u16)>,
+}
+
+impl Default for SuperScopeRegister {
+    fn default() -> Self {
+        Self {
+            fire: false,
+            cursor: false,
+            pause: false,
+            turbo: false,
+            offscreen: true,
+            position: None,
+        }
+    }
+}
+
+impl SuperScopeRegister {
+    fn update(&mut self, current_state: SuperScopeState, last_strobe_state: SuperScopeState) {
+        if current_state.fire && !last_strobe_state.fire {
+            // Turbo bit updates only when fire is pressed
+            self.turbo = current_state.turbo;
+        }
+
+        // If turbo is off, fire bit is only set for one strobe after the button is pressed
+        self.fire = if current_state.turbo {
+            current_state.fire
+        } else {
+            current_state.fire && !last_strobe_state.fire
+        };
+
+        // Cursor bit is always set to button press state
+        self.cursor = current_state.cursor;
+
+        // Pause is only set for one strobe after the button is pressed
+        self.pause = current_state.pause && !last_strobe_state.pause;
+
+        // Offscreen bit is only updated when fire or cursor bit is set
+        if self.fire || self.cursor {
+            self.offscreen = current_state.position.is_none();
+        }
+
+        // Position is only used for latching, which only occurs when fire or cursor bit is set
+        self.position = current_state.position;
+    }
+
+    fn to_register_word(self) -> u16 {
+        (u16::from(self.fire) << 15)
+            | (u16::from(self.cursor) << 14)
+            | (u16::from(self.turbo) << 13)
+            | (u16::from(self.pause) << 12)
+            | (u16::from(self.offscreen) << 9)
+            | 0x00FF
+    }
+}
+
+#[derive(Debug, Clone, Encode, Decode)]
+pub struct InputState {
+    auto_read_cycles_remaining: u64,
+    auto_joypad_p1_inputs: u16,
+    auto_joypad_p2_inputs: u16,
+    strobe: bool,
+    manual_joypad_p1_inputs: u16,
+    manual_joypad_p2_inputs: u16,
+    current_inputs: SnesInputs,
+    last_strobe_inputs: SnesInputs,
+    super_scope_register: SuperScopeRegister,
+}
+
+impl InputState {
+    pub fn new() -> Self {
+        Self {
+            auto_read_cycles_remaining: 0,
+            auto_joypad_p1_inputs: SnesJoypadState::default().to_register_word(),
+            auto_joypad_p2_inputs: SnesJoypadState::default().to_register_word(),
+            strobe: false,
+            manual_joypad_p1_inputs: SnesJoypadState::default().to_register_word(),
+            manual_joypad_p2_inputs: SnesJoypadState::default().to_register_word(),
+            current_inputs: SnesInputs::default(),
+            last_strobe_inputs: SnesInputs::default(),
+            super_scope_register: SuperScopeRegister::default(),
+        }
+    }
+
+    pub fn set_strobe(&mut self, strobe: bool) {
+        if !self.strobe && strobe {
+            self.manual_joypad_p1_inputs = self.current_inputs.p1.to_register_word();
+            self.manual_joypad_p2_inputs = match self.current_inputs.p2 {
+                SnesInputDevice::Controller(joypad_state) => {
+                    self.super_scope_register = SuperScopeRegister::default();
+
+                    joypad_state.to_register_word()
+                }
+                SnesInputDevice::SuperScope(super_scope_state) => {
+                    // Read out the bits before updating them; otherwise the SNES will read Fire=1 on the frame before
+                    // the PPU latches H/V
+                    let word = self.super_scope_register.to_register_word();
+
+                    let last_strobe_state = match self.last_strobe_inputs.p2 {
+                        SnesInputDevice::SuperScope(last_state) => last_state,
+                        SnesInputDevice::Controller(_) => SuperScopeState::default(),
+                    };
+                    self.super_scope_register.update(super_scope_state, last_strobe_state);
+
+                    word
+                }
+            };
+
+            self.last_strobe_inputs = self.current_inputs.clone();
+        }
+
+        self.strobe = strobe;
+    }
+
+    pub fn auto_joypad_read_in_progress(&self) -> bool {
+        self.auto_read_cycles_remaining != 0
+    }
+
+    pub fn auto_joypad_p1_inputs(&self) -> u16 {
+        self.auto_joypad_p1_inputs
+    }
+
+    pub fn auto_joypad_p2_inputs(&self) -> u16 {
+        self.auto_joypad_p2_inputs
+    }
+
+    pub fn next_manual_p1_bit(&mut self) -> bool {
+        let bit = self.manual_joypad_p1_inputs.bit(15);
+        self.manual_joypad_p1_inputs = (self.manual_joypad_p1_inputs << 1) | 0x0001;
+        bit
+    }
+
+    pub fn next_manual_p2_bit(&mut self) -> bool {
+        let bit = self.manual_joypad_p2_inputs.bit(15);
+        self.manual_joypad_p2_inputs = (self.manual_joypad_p2_inputs << 1) | 0x0001;
+        bit
+    }
+
+    pub fn start_auto_joypad_read(&mut self) {
+        self.auto_read_cycles_remaining = AUTO_JOYPAD_DURATION_MCLK;
+    }
+
+    pub fn tick(&mut self, master_cycles_elapsed: u64, inputs: &SnesInputs) {
+        self.current_inputs = inputs.clone();
+
+        if self.auto_read_cycles_remaining != 0 {
+            self.progress_auto_joypad_read(master_cycles_elapsed);
+        }
+    }
+
+    fn progress_auto_joypad_read(&mut self, master_cycles_elapsed: u64) {
+        self.auto_read_cycles_remaining =
+            self.auto_read_cycles_remaining.saturating_sub(master_cycles_elapsed);
+
+        if self.auto_read_cycles_remaining == 0 {
+            // Auto joypad read strobes the joypad while reading inputs; this populates the manual
+            // joypad read registers
+            self.set_strobe(true);
+            self.set_strobe(false);
+
+            // Drain the manual joypad read registers into the auto joypad read registers
+            // Donkey Kong Country depends on the manual joypad read registers reading out 1s after
+            // auto joypad read finishes
+            self.auto_joypad_p1_inputs = mem::replace(&mut self.manual_joypad_p1_inputs, !0);
+            self.auto_joypad_p2_inputs = mem::replace(&mut self.manual_joypad_p2_inputs, !0);
+        }
+    }
+
+    pub fn hv_latch(&self) -> Option<(u16, u16)> {
+        // Super Scope latches the PPU at H=X+40, V=Y+1 when Fire or Cursor is set
+        (self.super_scope_register.fire || self.super_scope_register.cursor)
+            .then(|| {
+                let (x, y) = self.super_scope_register.position?;
+                Some((x + 40, y + 1))
+            })
+            .flatten()
+    }
+}

--- a/backend/snes-core/src/ppu.rs
+++ b/backend/snes-core/src/ppu.rs
@@ -1607,6 +1607,17 @@ impl Ppu {
         }
     }
 
+    pub fn update_controller_hv_latch(&mut self, h: u16, v: u16, master_cycles_elapsed: u64) {
+        if v == self.state.scanline
+            && h > (self.state.scanline_master_cycles / 4) as u16
+            && h <= ((self.state.scanline_master_cycles + master_cycles_elapsed) / 4) as u16
+        {
+            self.registers.latched_h_counter = h;
+            self.registers.latched_v_counter = v;
+            self.registers.new_hv_latched = true;
+        }
+    }
+
     pub fn reset(&mut self) {
         // Enable forced blanking
         self.registers.write_inidisp(0x80, self.is_first_vblank_scanline());

--- a/frontend/jgenesis-cli/src/main.rs
+++ b/frontend/jgenesis-cli/src/main.rs
@@ -4,7 +4,7 @@ use genesis_core::{GenesisAspectRatio, GenesisControllerType, GenesisRegion};
 use jgenesis_common::frontend::TimingMode;
 use jgenesis_native_driver::config::input::{
     GenesisControllerConfig, GenesisInputConfig, HotkeyConfig, KeyboardInput,
-    SmsGgControllerConfig, SmsGgInputConfig, SnesInputConfig,
+    SmsGgControllerConfig, SmsGgInputConfig, SnesControllerType, SnesInputConfig, SuperScopeConfig,
 };
 use jgenesis_native_driver::config::{
     CommonConfig, GenesisConfig, GgAspectRatio, SegaCdConfig, SmsAspectRatio, SmsGgConfig,
@@ -576,6 +576,8 @@ fn run_sega_cd(args: Args) -> anyhow::Result<()> {
 fn run_snes(args: Args) -> anyhow::Result<()> {
     let config = SnesConfig {
         common: args.common_config(SnesInputConfig::default(), SnesInputConfig::default()),
+        p2_controller_type: SnesControllerType::default(),
+        super_scope_config: SuperScopeConfig::default(),
         forced_timing_mode: args.snes_timing_mode,
         aspect_ratio: args.snes_aspect_ratio,
         audio_60hz_hack: args.snes_audio_60hz_hack,

--- a/frontend/jgenesis-cli/src/main.rs
+++ b/frontend/jgenesis-cli/src/main.rs
@@ -143,6 +143,10 @@ struct Args {
     #[arg(long, default_value_t = NonZeroU64::new(1).unwrap(), help_heading = SNES_OPTIONS_HEADING)]
     gsu_overclock_factor: NonZeroU64,
 
+    /// Player 2 input device (Gamepad / SuperScope)
+    #[arg(long, default_value_t, help_heading = SNES_OPTIONS_HEADING)]
+    snes_p2_controller_type: SnesControllerType,
+
     /// Specify SNES DSP-1 ROM path (required for DSP-1 games)
     #[arg(long, help_heading = SNES_OPTIONS_HEADING)]
     dsp1_rom_path: Option<String>,
@@ -576,7 +580,7 @@ fn run_sega_cd(args: Args) -> anyhow::Result<()> {
 fn run_snes(args: Args) -> anyhow::Result<()> {
     let config = SnesConfig {
         common: args.common_config(SnesInputConfig::default(), SnesInputConfig::default()),
-        p2_controller_type: SnesControllerType::default(),
+        p2_controller_type: args.snes_p2_controller_type,
         super_scope_config: SuperScopeConfig::default(),
         forced_timing_mode: args.snes_timing_mode,
         aspect_ratio: args.snes_aspect_ratio,

--- a/frontend/jgenesis-gui/src/app.rs
+++ b/frontend/jgenesis-gui/src/app.rs
@@ -345,6 +345,8 @@ impl AppConfig {
                 self.inputs.to_snes_keyboard_config(),
                 self.inputs.to_snes_joystick_config(),
             ),
+            p2_controller_type: self.inputs.snes_p2_type,
+            super_scope_config: self.inputs.snes_super_scope.clone(),
             forced_timing_mode: self.snes.forced_timing_mode,
             aspect_ratio: self.snes.aspect_ratio,
             audio_60hz_hack: self.snes.audio_60hz_hack,
@@ -385,6 +387,7 @@ enum OpenWindow {
     GenesisGamepad,
     SnesKeyboard,
     SnesGamepad,
+    SnesPeripherals,
     Hotkeys,
     About,
 }
@@ -1529,6 +1532,11 @@ impl App {
                         ui.close_menu();
                     }
 
+                    if ui.button("SNES Peripherals").clicked() {
+                        self.state.open_windows.insert(OpenWindow::SnesPeripherals);
+                        ui.close_menu();
+                    }
+
                     if ui.button("Hotkeys").clicked() {
                         self.state.open_windows.insert(OpenWindow::Hotkeys);
                         ui.close_menu();
@@ -1702,6 +1710,7 @@ impl eframe::App for App {
                 OpenWindow::GenesisGamepad => self.render_genesis_gamepad_settings(ctx),
                 OpenWindow::SnesKeyboard => self.render_snes_keyboard_settings(ctx),
                 OpenWindow::SnesGamepad => self.render_snes_gamepad_settings(ctx),
+                OpenWindow::SnesPeripherals => self.render_snes_peripheral_settings(ctx),
                 OpenWindow::Hotkeys => self.render_hotkey_settings(ctx),
                 OpenWindow::About => self.render_about(ctx),
             }

--- a/frontend/jgenesis-native-driver/src/config.rs
+++ b/frontend/jgenesis-native-driver/src/config.rs
@@ -225,6 +225,7 @@ pub struct SnesConfig {
     #[indent_nested]
     pub common: CommonConfig<SnesInputConfig<KeyboardInput>, SnesInputConfig<JoystickInput>>,
     pub p2_controller_type: SnesControllerType,
+    #[indent_nested]
     pub super_scope_config: SuperScopeConfig,
     pub forced_timing_mode: Option<TimingMode>,
     pub aspect_ratio: SnesAspectRatio,

--- a/frontend/jgenesis-native-driver/src/config.rs
+++ b/frontend/jgenesis-native-driver/src/config.rs
@@ -2,7 +2,7 @@ pub mod input;
 
 use crate::config::input::{
     GenesisInputConfig, HotkeyConfig, JoystickInput, KeyboardInput, SmsGgInputConfig,
-    SnesInputConfig,
+    SnesControllerType, SnesInputConfig, SuperScopeConfig,
 };
 use genesis_core::{
     GenesisAspectRatio, GenesisControllerType, GenesisEmulatorConfig, GenesisRegion,
@@ -224,6 +224,8 @@ impl SegaCdConfig {
 pub struct SnesConfig {
     #[indent_nested]
     pub common: CommonConfig<SnesInputConfig<KeyboardInput>, SnesInputConfig<JoystickInput>>,
+    pub p2_controller_type: SnesControllerType,
+    pub super_scope_config: SuperScopeConfig,
     pub forced_timing_mode: Option<TimingMode>,
     pub aspect_ratio: SnesAspectRatio,
     pub audio_60hz_hack: bool,

--- a/frontend/jgenesis-native-driver/src/config/input.rs
+++ b/frontend/jgenesis-native-driver/src/config/input.rs
@@ -1,4 +1,4 @@
-use jgenesis_proc_macros::{ConfigDisplay, EnumDisplay};
+use jgenesis_proc_macros::{ConfigDisplay, EnumDisplay, EnumFromStr};
 use sdl2::keyboard::Keycode;
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
@@ -392,7 +392,9 @@ impl Default for SuperScopeConfig {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize, EnumDisplay)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize, EnumDisplay, EnumFromStr,
+)]
 pub enum SnesControllerType {
     #[default]
     Gamepad,

--- a/frontend/jgenesis-native-driver/src/config/input.rs
+++ b/frontend/jgenesis-native-driver/src/config/input.rs
@@ -87,6 +87,29 @@ impl Display for KeyboardInput {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum KeyboardOrMouseInput {
+    Keyboard(String),
+    MouseLeft,
+    MouseRight,
+    MouseMiddle,
+    MouseX1,
+    MouseX2,
+}
+
+impl Display for KeyboardOrMouseInput {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Keyboard(keycode) => write!(f, "{keycode}"),
+            Self::MouseLeft => write!(f, "Mouse Left Button"),
+            Self::MouseRight => write!(f, "Mouse Right Button"),
+            Self::MouseMiddle => write!(f, "Mouse Middle Button"),
+            Self::MouseX1 => write!(f, "Mouse Extra Button 1"),
+            Self::MouseX2 => write!(f, "Mouse Extra Button 2"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SmsGgControllerConfig<Input> {
     pub up: Option<Input>,
     pub left: Option<Input>,
@@ -348,6 +371,32 @@ impl Default for SnesInputConfig<JoystickInput> {
     fn default() -> Self {
         Self { p1: SnesControllerConfig::default(), p2: SnesControllerConfig::default() }
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ConfigDisplay)]
+pub struct SuperScopeConfig {
+    pub fire: Option<KeyboardOrMouseInput>,
+    pub cursor: Option<KeyboardOrMouseInput>,
+    pub pause: Option<KeyboardOrMouseInput>,
+    pub turbo_toggle: Option<KeyboardOrMouseInput>,
+}
+
+impl Default for SuperScopeConfig {
+    fn default() -> Self {
+        Self {
+            fire: Some(KeyboardOrMouseInput::MouseLeft),
+            cursor: Some(KeyboardOrMouseInput::MouseRight),
+            pause: Some(KeyboardOrMouseInput::MouseMiddle),
+            turbo_toggle: Some(KeyboardOrMouseInput::Keyboard("T".into())),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize, EnumDisplay)]
+pub enum SnesControllerType {
+    #[default]
+    Gamepad,
+    SuperScope,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, ConfigDisplay, Serialize, Deserialize)]

--- a/frontend/jgenesis-native-driver/src/mainloop.rs
+++ b/frontend/jgenesis-native-driver/src/mainloop.rs
@@ -6,7 +6,7 @@ use crate::config::{
     CommonConfig, GenesisConfig, SegaCdConfig, SmsGgConfig, SnesConfig, WindowSize,
 };
 use crate::input::{
-    GenesisButton, GetButtonField, Hotkey, HotkeyMapResult, HotkeyMapper, InputMapper, Joysticks,
+    GenesisButton, Hotkey, HotkeyMapResult, HotkeyMapper, InputMapper, Joysticks, SetButtonField,
     SmsGgButton, SnesButton,
 };
 use crate::mainloop::debug::{DebugRenderFn, DebuggerWindow};
@@ -542,7 +542,7 @@ pub type NativeEmulatorResult<T> = Result<T, NativeEmulatorError>;
 // TODO simplify or generalize these trait bounds
 impl<Inputs, Button, Config, Emulator> NativeEmulator<Inputs, Button, Config, Emulator>
 where
-    Inputs: Default + GetButtonField<Button>,
+    Inputs: Default + SetButtonField<Button>,
     Button: Copy,
     Emulator: EmulatorTrait<Inputs = Inputs, Config = Config>,
     Emulator::Err<RendererError, AudioError, SaveWriteError>: Error + Send + Sync + 'static,

--- a/frontend/jgenesis-renderer/src/renderer.rs
+++ b/frontend/jgenesis-renderer/src/renderer.rs
@@ -971,13 +971,13 @@ impl<Window> WgpuRenderer<Window> {
         self.speed_multiplier = speed_multiplier;
     }
 
-    /// Obtain the current display area within the window.
+    /// Obtain the last rendered frame size and the current display area within the window.
     ///
     /// May return None if rendering config was just changed or initialized and a frame has not yet been rendered with
     /// the new config.
     #[must_use]
-    pub fn current_display_area(&self) -> Option<DisplayArea> {
-        self.pipeline.as_ref().map(|pipeline| pipeline.display_area)
+    pub fn current_display_info(&self) -> Option<(FrameSize, DisplayArea)> {
+        self.pipeline.as_ref().map(|pipeline| (pipeline.frame_size, pipeline.display_area))
     }
 }
 


### PR DESCRIPTION
The Super Scope was a bazooka-shaped light gun peripheral supported by 12 games, most notably _Yoshi's Safari_, _Battle Clash_, and _Metal Combat: Falcon's Revenge_.

The light gun works by sensing the TV's electron beam and then sending a signal to the PPU telling it to latch the current H/V position (if the Fire or Cursor button is pressed). When the game program reads that Fire or Cursor is pressed, it can then read out the latched H/V values to tell where onscreen the light gun was pointing when the button was pressed. The light gun does not work on modern TVs (LCD etc.) since there is no electron beam to sense.

The Super Scope position can be controlled with the mouse cursor, and the 4 Super Scope buttons (Fire/Cursor/Pause/Turbo) can be mapped to either keys or mouse buttons. The Turbo button mapping is a toggle rather than needing to be held down, since on the actual Super Scope it's a third position for the power switch.