### PR TITLE
xrandr is NOT Linux only

### DIFF
--- a/frontend/jgenesis-gui/Cargo.toml
+++ b/frontend/jgenesis-gui/Cargo.toml
@@ -33,7 +33,7 @@ sdl2 = { workspace = true }
 time = { workspace = true, features = ["formatting", "local-offset"] }
 toml = { workspace = true }
 
-[target.'cfg(target_os = "linux")'.dependencies]
+[target.'cfg(all(unix, not(target_os = "macos")))'.dependencies]
 xrandr = { workspace = true }
 
 [package.metadata.packager]


### PR DESCRIPTION
Hi,

I've packaged `jgenesis` for NetBSD during the weekend and the package has just been merged.

[Commit log](https://mail-index.netbsd.org/pkgsrc-changes/2024/08/12/msg305369.html) for your reference.

During the process I found a minor issue which, this patch addresses. Hope it can be merged and improve accessibility of future releases on other *nixes.

Thanks!