### PR TITLE
Draft: enable webgpu conditional compile.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1244,7 +1244,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b28bfe653d79bd16c77f659305b195b82bb5ce0c0eb2a4846b82ddbd77586813"
 dependencies = [
  "bitflags 2.6.0",
- "libloading 0.8.5",
+ "libloading 0.7.4",
  "winapi",
 ]
 

--- a/frontend/jgenesis-renderer/src/config.rs
+++ b/frontend/jgenesis-renderer/src/config.rs
@@ -12,6 +12,7 @@ pub enum WgpuBackend {
     Vulkan,
     DirectX12,
     OpenGl,
+    WebGPU
 }
 
 #[derive(

--- a/frontend/jgenesis-renderer/src/renderer.rs
+++ b/frontend/jgenesis-renderer/src/renderer.rs
@@ -924,7 +924,7 @@ impl<Window: HasDisplayHandle + HasWindowHandle> WgpuRenderer<Window> {
         config: RendererConfig,
     ) -> Result<Self, RendererError> {
         let backends = match config.wgpu_backend {
-            WgpuBackend::Auto => wgpu::Backends::PRIMARY,
+            WgpuBackend::Auto => wgpu::Backends::all(),
             WgpuBackend::Vulkan => wgpu::Backends::VULKAN,
             WgpuBackend::DirectX12 => wgpu::Backends::DX12,
             WgpuBackend::OpenGl => wgpu::Backends::GL,

--- a/frontend/jgenesis-renderer/src/renderer.rs
+++ b/frontend/jgenesis-renderer/src/renderer.rs
@@ -928,6 +928,7 @@ impl<Window: HasDisplayHandle + HasWindowHandle> WgpuRenderer<Window> {
             WgpuBackend::Vulkan => wgpu::Backends::VULKAN,
             WgpuBackend::DirectX12 => wgpu::Backends::DX12,
             WgpuBackend::OpenGl => wgpu::Backends::GL,
+            WgpuBackend::WebGPU => wgpu::Backends::BROWSER_WEBGPU,
         };
 
         let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {

--- a/frontend/jgenesis-web/Cargo.toml
+++ b/frontend/jgenesis-web/Cargo.toml
@@ -52,7 +52,9 @@ features = [
 ]
 
 [features]
+default = ["auto-renderer"]
 webgpu = []
+auto-renderer = []
 
 [lints]
 workspace = true

--- a/frontend/jgenesis-web/Cargo.toml
+++ b/frontend/jgenesis-web/Cargo.toml
@@ -51,5 +51,8 @@ features = [
     "Performance",
 ]
 
+[features]
+webgpu = []
+
 [lints]
 workspace = true

--- a/frontend/jgenesis-web/src/config.rs
+++ b/frontend/jgenesis-web/src/config.rs
@@ -72,8 +72,13 @@ impl Default for CommonWebConfig {
 
 impl CommonWebConfig {
     pub fn to_renderer_config(&self) -> RendererConfig {
+        let renderer = if cfg!(feature = "webgpu") {
+            WgpuBackend::WebGPU
+        } else {
+            WgpuBackend::OpenGl
+        };
         RendererConfig {
-            wgpu_backend: WgpuBackend::OpenGl,
+            wgpu_backend: renderer,
             vsync_mode: VSyncMode::Enabled,
             prescale_mode: PrescaleMode::Manual(self.prescale_factor),
             scanlines: Scanlines::default(),

--- a/frontend/jgenesis-web/src/config.rs
+++ b/frontend/jgenesis-web/src/config.rs
@@ -72,7 +72,9 @@ impl Default for CommonWebConfig {
 
 impl CommonWebConfig {
     pub fn to_renderer_config(&self) -> RendererConfig {
-        let renderer = if cfg!(feature = "webgpu") {
+        let renderer = if cfg!(feature = "auto-renderer") {
+            WgpuBackend::Auto
+        } else if cfg!(feature = "webgpu") {
             WgpuBackend::WebGPU
         } else {
             WgpuBackend::OpenGl


### PR DESCRIPTION
Conditional compile for webgpu support, tested in both chromium and firefox-nightly to work. I did try servo but it was hitting a bug I will try to debug at a later point, that's to be expected since servo is still very beta.

I elected to put this behind a build flag since 

A) I havent learned the interop stuff for this yet
B) It's behind a nightly browser for firefox, and a config flag for chrome anyways so nothing can actually use it out of box
C) Not sure how to best handle configuring it to begin with. Perhaps an option above image filtering? Not sure how changing that live would work anyways.

Cargo keeps force changing libloading in cargo.lock me, not sure why.

EDIT: I did notice a slight improvement when playing sonic-cd with this, I dont have many other games to test.