### PR TITLE
Genesis: CRAM dots and support for Direct Color DMA demos

### DIFF
--- a/backend/genesis-core/src/vdp.rs
+++ b/backend/genesis-core/src/vdp.rs
@@ -1320,9 +1320,11 @@ impl Vdp {
         let access_slots = h_display_size.access_slots();
         let blank_refresh_slots = h_display_size.blank_refresh_slots();
 
+        let check_access_slots = self.control_port.dma_active || !self.fifo.is_empty();
+
         while self.state.pixel < end_pixel {
             let pixel = self.state.pixel;
-            if (self.control_port.dma_active || !self.fifo.is_empty()) && !pixel.bit(0) {
+            if check_access_slots && !pixel.bit(0) {
                 let slot_idx = (pixel >> 1) as u8;
                 let blank = !self.registers.display_enabled || self.state.in_vblank;
                 if (blank && !blank_refresh_slots[slot_idx as usize])

--- a/backend/genesis-core/src/vdp/cramdots.rs
+++ b/backend/genesis-core/src/vdp/cramdots.rs
@@ -1,0 +1,163 @@
+use crate::vdp::colors::ColorModifier;
+use crate::vdp::fifo::VdpFifo;
+use crate::vdp::registers::{InterlacingMode, RIGHT_BORDER, Registers};
+use crate::vdp::render::RasterLine;
+use crate::vdp::{MAX_SCREEN_WIDTH, Vdp, render};
+use bincode::{Decode, Encode};
+use std::num::NonZeroU16;
+use std::ops::Range;
+use std::{array, mem};
+
+// Use NonZeroU16 to cut the buffer sizes in half
+type LineDotBuffer = [Option<NonZeroU16>; MAX_SCREEN_WIDTH];
+
+#[derive(Debug, Clone, Encode, Decode)]
+struct LineBuffer {
+    dots: Box<LineDotBuffer>,
+    any: bool,
+}
+
+impl LineBuffer {
+    fn new() -> Self {
+        Self { dots: Box::new(array::from_fn(|_| None)), any: false }
+    }
+
+    fn clear(&mut self) {
+        self.dots.fill(None);
+        self.any = false;
+    }
+}
+
+#[derive(Debug, Clone, Encode, Decode)]
+pub struct CramDotBuffer {
+    prev_line: LineBuffer,
+    current_line: LineBuffer,
+}
+
+impl CramDotBuffer {
+    pub fn new() -> Self {
+        Self { prev_line: LineBuffer::new(), current_line: LineBuffer::new() }
+    }
+
+    pub fn check_for_dot(
+        &mut self,
+        registers: &Registers,
+        fifo: &VdpFifo,
+        pixel: u16,
+        cram_addr: u32,
+        color: u16,
+    ) {
+        let h_display_size = registers.horizontal_display_size;
+        let active_display_range = h_display_size.active_display_h_range();
+        let left_border = h_display_size.left_border();
+
+        // +4 is necessary for correct alignment of Direct Color DMA demos
+        // Also to avoid CRAM dots being visible within active display on some screens in Overdrive 1
+        let left = active_display_range.start - left_border + 4;
+        let right = active_display_range.end + RIGHT_BORDER + 4;
+
+        self.check_for_dot_inner(left..right, pixel, color);
+
+        // Hack: Use "CRAM dots" to make Direct Color DMA demos work
+        // If the backdrop color is changed while display is disabled, fill in some following pixels
+        // with the new backdrop color
+        if !registers.display_enabled
+            && (cram_addr >> 4) as u8 == registers.background_palette
+            && (cram_addr & 0xF) as u8 == registers.background_color_id
+        {
+            let n = if fifo.len() > 1 {
+                // Filling in 3 pixels is necessary to avoid vertical lines around refresh slots
+                3
+            } else {
+                right.saturating_sub(pixel)
+            };
+            for i in 1..=n {
+                self.check_for_dot_inner(left..right, pixel + i, color);
+            }
+        }
+    }
+
+    fn check_for_dot_inner(&mut self, range: Range<u16>, pixel: u16, color: u16) {
+        if !range.contains(&pixel) {
+            return;
+        }
+
+        let idx = (pixel - range.start) as usize;
+        self.current_line.dots[idx] = Some(NonZeroU16::new(color | 0x8000).unwrap());
+        self.current_line.any = true;
+    }
+
+    pub fn swap_buffers_if_needed(&mut self) {
+        if !self.current_line.any && !self.prev_line.any {
+            return;
+        }
+
+        mem::swap(&mut self.current_line.dots, &mut self.prev_line.dots);
+        self.prev_line.any = self.current_line.any;
+        self.current_line.clear();
+    }
+}
+
+impl Vdp {
+    pub(super) fn apply_cram_dots_previous_line(&mut self, line: RasterLine) {
+        if !self.cram_dots.prev_line.any {
+            return;
+        }
+
+        let timing_mode = self.timing_mode;
+        let h_display_size = self.registers.horizontal_display_size;
+        let v_display_size = self.registers.vertical_display_size;
+
+        let prev_line = line.previous_line(v_display_size);
+        let Some(mut fb_row) = prev_line.to_frame_buffer_row(
+            v_display_size.top_border(timing_mode),
+            timing_mode,
+            self.config.render_vertical_border,
+        ) else {
+            return;
+        };
+
+        let interlaced_resolution = self.state.interlaced_frame
+            && !(self.config.deinterlace
+                && self.registers.interlacing_mode == InterlacingMode::Interlaced);
+        if interlaced_resolution {
+            fb_row *= 2;
+            if self.state.interlaced_odd {
+                fb_row += 1;
+            }
+        }
+
+        let screen_width = self.screen_width();
+        let left_border_offset = if self.config.render_horizontal_border {
+            0
+        } else {
+            -i32::from(h_display_size.left_border())
+        };
+
+        self.apply_cram_dots_inner(fb_row, screen_width, left_border_offset);
+        if interlaced_resolution && self.config.deinterlace {
+            self.apply_cram_dots_inner(fb_row ^ 1, screen_width, left_border_offset);
+        }
+    }
+
+    fn apply_cram_dots_inner(&mut self, fb_row: u32, screen_width: u32, left_border_offset: i32) {
+        for (x, color) in self.cram_dots.prev_line.dots.iter().copied().enumerate() {
+            let Some(color) = color.map(NonZeroU16::get) else { continue };
+
+            let fb_col = x as i32 + left_border_offset;
+            if !(0..screen_width as i32).contains(&fb_col) {
+                continue;
+            }
+
+            render::set_in_frame_buffer(
+                &mut self.frame_buffer,
+                fb_row,
+                fb_col as u32,
+                color,
+                ColorModifier::None,
+                screen_width,
+                self.config.non_linear_color_scale,
+            );
+        }
+    }
+}

--- a/backend/genesis-core/src/vdp/render.rs
+++ b/backend/genesis-core/src/vdp/render.rs
@@ -163,6 +163,10 @@ impl Vdp {
                 }
             }
         }
+
+        if starting_pixel == 0 {
+            self.apply_cram_dots_previous_line(raster_line);
+        }
     }
 
     fn do_render_scanline(
@@ -859,7 +863,7 @@ impl Vdp {
     }
 }
 
-fn set_in_frame_buffer(
+pub(super) fn set_in_frame_buffer(
     frame_buffer: &mut FrameBuffer,
     row: u32,
     col: u32,


### PR DESCRIPTION
After #303, VDP timings are accurate enough to support CRAM dots and Direct Color DMA demos, so here they are.

I had to fudge the CRAM dot timings a little bit to avoid CRAM dots during active display on some screens in Overdrive 1. Might be caused by other underlying VDP timing issues, or possibly timing issues related to 68000/VDP interactions.

CRAM dots in Sonic 2, in both progressive and interlaced modes:

![sonic-2-title](https://github.com/user-attachments/assets/6862414d-ce20-47f8-bcf9-53e74ae2ffad)
![interlaced-cram-dots](https://github.com/user-attachments/assets/3c050bae-cebf-47f7-b731-04fb7d599d28)

One of the Direct Color DMA demos:

![direct-color-dma](https://github.com/user-attachments/assets/69bcca45-e3b3-40b6-af02-febff1ca276c)
