### PR TITLE
Game Boy Advance

### DIFF
--- a/frontend/jgenesis-cli/Cargo.toml
+++ b/frontend/jgenesis-cli/Cargo.toml
@@ -7,11 +7,11 @@ edition = "2024"
 
 [features]
 default = []
-unstable-cores = ["dep:gba-config", "jgenesis-native-driver/gba"]
+unstable-cores = []
 
 [dependencies]
 gb-config = { path = "../../config/gb-config", features = ["clap"] }
-gba-config = { path = "../../config/gba-config", features = ["clap"], optional = true }
+gba-config = { path = "../../config/gba-config", features = ["clap"] }
 genesis-config = { path = "../../config/genesis-config", features = ["clap"] }
 nes-config = { path = "../../config/nes-config", features = ["clap"] }
 smsgg-config = { path = "../../config/smsgg-config", features = ["clap"] }

--- a/frontend/jgenesis-gui/Cargo.toml
+++ b/frontend/jgenesis-gui/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2024"
 
 [features]
 default = []
-unstable-cores = ["dep:gba-config", "jgenesis-native-driver/gba", "jgenesis-native-config/gba"]
+unstable-cores = []
 
 [dependencies]
 jgenesis-common = { path = "../../common/jgenesis-common", features = ["serde"] }
@@ -20,7 +20,7 @@ smsgg-core = { path = "../../backend/smsgg-core" }
 snes-core = { path = "../../backend/snes-core" }
 
 gb-config = { path = "../../config/gb-config" }
-gba-config = { path = "../../config/gba-config", optional = true }
+gba-config = { path = "../../config/gba-config" }
 genesis-config = { path = "../../config/genesis-config" }
 nes-config = { path = "../../config/nes-config" }
 smsgg-config = { path = "../../config/smsgg-config" }

--- a/frontend/jgenesis-gui/src/app.rs
+++ b/frontend/jgenesis-gui/src/app.rs
@@ -1,6 +1,5 @@
 mod common;
 mod gb;
-#[cfg(feature = "unstable-cores")]
 mod gba;
 mod genesis;
 mod input;
@@ -64,7 +63,6 @@ impl ListFiltersExt for ListFilters {
             self.snes.then_some(Console::Snes),
             self.game_boy.then_some(Console::GameBoy),
             self.game_boy_color.then_some(Console::GameBoyColor),
-            #[cfg(feature = "unstable-cores")]
             self.game_boy_advance.then_some(Console::GameBoyAdvance),
         ]
         .into_iter()
@@ -97,7 +95,6 @@ enum OpenWindow {
     NesGeneral,
     SnesGeneral,
     GameBoyGeneral,
-    #[cfg(feature = "unstable-cores")]
     GbaGeneral,
     Synchronization,
     Paths,
@@ -108,7 +105,6 @@ enum OpenWindow {
     NesVideo,
     SnesVideo,
     GameBoyVideo,
-    #[cfg(feature = "unstable-cores")]
     GbaVideo,
     CommonAudio,
     SmsGgAudio,
@@ -124,7 +120,6 @@ enum OpenWindow {
     SnesInput,
     SnesPeripherals,
     GameBoyInput,
-    #[cfg(feature = "unstable-cores")]
     GbaInput,
     Hotkeys,
     About,
@@ -710,7 +705,6 @@ impl App {
                 ui.close_menu();
             }
 
-            #[cfg(feature = "unstable-cores")]
             if ui.button("Game Boy Advance").clicked() {
                 self.state.open_windows.insert(OpenWindow::GbaGeneral);
                 ui.close_menu();
@@ -769,7 +763,6 @@ impl App {
                 ui.close_menu();
             }
 
-            #[cfg(feature = "unstable-cores")]
             if ui.button("Game Boy Advance").clicked() {
                 self.state.open_windows.insert(OpenWindow::GbaVideo);
                 ui.close_menu();
@@ -861,7 +854,6 @@ impl App {
                 ui.close_menu();
             }
 
-            #[cfg(feature = "unstable-cores")]
             if ui.button("Game Boy Advance").clicked() {
                 self.state.open_windows.insert(OpenWindow::GbaInput);
                 ui.close_menu();
@@ -1009,7 +1001,6 @@ impl App {
             ui.checkbox(&mut self.config.list_filters.snes, "SNES");
             ui.checkbox(&mut self.config.list_filters.game_boy, "GB");
             ui.checkbox(&mut self.config.list_filters.game_boy_color, "GBC");
-            #[cfg(feature = "unstable-cores")]
             ui.checkbox(&mut self.config.list_filters.game_boy_advance, "GBA");
 
             if prev_list_filters != self.config.list_filters {
@@ -1027,7 +1018,6 @@ impl App {
                 OpenWindow::NesGeneral => self.render_nes_general_settings(ctx),
                 OpenWindow::SnesGeneral => self.render_snes_general_settings(ctx),
                 OpenWindow::GameBoyGeneral => self.render_gb_general_settings(ctx),
-                #[cfg(feature = "unstable-cores")]
                 OpenWindow::GbaGeneral => self.render_gba_general_settings(ctx),
                 OpenWindow::Synchronization => self.render_sync_settings(ctx),
                 OpenWindow::Paths => self.render_path_settings(ctx),
@@ -1038,7 +1028,6 @@ impl App {
                 OpenWindow::NesVideo => self.render_nes_video_settings(ctx),
                 OpenWindow::SnesVideo => self.render_snes_video_settings(ctx),
                 OpenWindow::GameBoyVideo => self.render_gb_video_settings(ctx),
-                #[cfg(feature = "unstable-cores")]
                 OpenWindow::GbaVideo => self.render_gba_video_settings(ctx),
                 OpenWindow::CommonAudio => self.render_common_audio_settings(ctx),
                 OpenWindow::SmsGgAudio => self.render_smsgg_audio_settings(ctx),
@@ -1054,7 +1043,6 @@ impl App {
                 OpenWindow::SnesInput => self.render_snes_input_settings(ctx),
                 OpenWindow::SnesPeripherals => self.render_snes_peripheral_settings(ctx),
                 OpenWindow::GameBoyInput => self.render_gb_input_settings(ctx),
-                #[cfg(feature = "unstable-cores")]
                 OpenWindow::GbaInput => self.render_gba_input_settings(ctx),
                 OpenWindow::Hotkeys => self.render_hotkey_settings(ctx),
                 OpenWindow::About => self.render_about(ctx),
@@ -1102,7 +1090,6 @@ impl App {
                         HandledError::No => Self::render_generic_error_window(ctx, err, &mut open),
                     }
                 }
-                #[cfg(feature = "unstable-cores")]
                 NativeEmulatorError::GbaNoBios => self.render_gba_bios_error(ctx, &mut open),
                 _ => Self::render_generic_error_window(ctx, err, &mut open),
             };

--- a/frontend/jgenesis-gui/src/app/input.rs
+++ b/frontend/jgenesis-gui/src/app/input.rs
@@ -3,16 +3,13 @@ use crate::app::{App, OpenWindow};
 use crate::emuthread::EmuThreadCommand;
 use egui::{Button, Color32, ComboBox, Context, Grid, ScrollArea, Slider, Ui, Window};
 use gb_config::GameBoyButton;
-#[cfg(feature = "unstable-cores")]
 use gba_config::GbaButton;
 use genesis_config::{GenesisButton, GenesisControllerType};
 use jgenesis_common::input::Player;
 use jgenesis_native_config::input::InputAppConfig;
-#[cfg(feature = "unstable-cores")]
-use jgenesis_native_config::input::mappings::GbaInputMapping;
 use jgenesis_native_config::input::mappings::{
-    GameBoyInputMapping, GenesisControllerMapping, GenesisInputMapping, HotkeyMapping,
-    NesControllerMapping, NesControllerType, NesInputMapping, NesZapperMapping,
+    GameBoyInputMapping, GbaInputMapping, GenesisControllerMapping, GenesisInputMapping,
+    HotkeyMapping, NesControllerMapping, NesControllerType, NesInputMapping, NesZapperMapping,
     SmsGgControllerMapping, SmsGgInputMapping, SnesControllerMapping, SnesControllerType,
     SnesInputMapping, SnesSuperScopeMapping,
 };
@@ -72,7 +69,6 @@ impl InputMappingSet {
         }
     }
 
-    #[cfg(feature = "unstable-cores")]
     fn gba(self, config: &mut InputAppConfig) -> &mut GbaInputMapping {
         match self {
             Self::One => &mut config.game_boy_advance.mapping_1,
@@ -95,7 +91,6 @@ pub enum GenericButton {
     Nes(NesButton, Player),
     Snes(SnesButton, Player),
     GameBoy(GameBoyButton),
-    #[cfg(feature = "unstable-cores")]
     Gba(GbaButton),
     Hotkey(Hotkey),
 }
@@ -108,7 +103,6 @@ impl GenericButton {
             Self::Nes(button, _) => nes_label(button),
             Self::Snes(button, _) => snes_label(button),
             Self::GameBoy(button) => gb_label(button),
-            #[cfg(feature = "unstable-cores")]
             Self::Gba(button) => gba_label(button),
             Self::Hotkey(hotkey) => hotkey_label(hotkey),
         }
@@ -125,7 +119,6 @@ impl GenericButton {
             Self::Nes(button, player) => access_nes_value(mapping, button, player, config),
             Self::Snes(button, player) => access_snes_value(mapping, button, player, config),
             Self::GameBoy(button) => access_gb_value(mapping, button, config),
-            #[cfg(feature = "unstable-cores")]
             Self::Gba(button) => access_gba_value(mapping, button, config),
             Self::Hotkey(hotkey) => access_hotkey(mapping, hotkey, config),
         }
@@ -220,7 +213,6 @@ fn gb_label(button: GameBoyButton) -> &'static str {
     }
 }
 
-#[cfg(feature = "unstable-cores")]
 fn gba_label(button: GbaButton) -> &'static str {
     use GbaButton::*;
 
@@ -431,7 +423,6 @@ fn access_gb_value(
     }
 }
 
-#[cfg(feature = "unstable-cores")]
 fn access_gba_value(
     mapping: InputMappingSet,
     button: GbaButton,
@@ -983,7 +974,6 @@ impl App {
         }
     }
 
-    #[cfg(feature = "unstable-cores")]
     pub(super) fn render_gba_input_settings(&mut self, ctx: &Context) {
         static BUTTONS: LazyLock<Vec<GenericButton>> =
             LazyLock::new(|| GbaButton::ALL.into_iter().map(GenericButton::Gba).collect());

--- a/frontend/jgenesis-gui/src/emuthread.rs
+++ b/frontend/jgenesis-gui/src/emuthread.rs
@@ -9,8 +9,9 @@ use jgenesis_native_driver::extensions::Console;
 use jgenesis_native_driver::input::Joysticks;
 use jgenesis_native_driver::{
     AudioError, Native32XEmulator, NativeEmulatorError, NativeEmulatorResult,
-    NativeGameBoyEmulator, NativeGenesisEmulator, NativeNesEmulator, NativeSegaCdEmulator,
-    NativeSmsGgEmulator, NativeSnesEmulator, NativeTickEffect, SaveStateMetadata,
+    NativeGameBoyEmulator, NativeGbaEmulator, NativeGenesisEmulator, NativeNesEmulator,
+    NativeSegaCdEmulator, NativeSmsGgEmulator, NativeSnesEmulator, NativeTickEffect,
+    SaveStateMetadata,
 };
 use jgenesis_proc_macros::MatchEachVariantMacro;
 use sdl2::EventPump;
@@ -89,7 +90,6 @@ impl ConsoleExt for Console {
             Self::Nes => EmuThreadStatus::RunningNes,
             Self::Snes => EmuThreadStatus::RunningSnes,
             Self::GameBoy | Self::GameBoyColor => EmuThreadStatus::RunningGameBoy,
-            #[cfg(feature = "unstable-cores")]
             Self::GameBoyAdvance => EmuThreadStatus::RunningGba,
         }
     }
@@ -317,8 +317,7 @@ enum GenericEmulator {
     Nes(Box<NativeNesEmulator>),
     Snes(Box<NativeSnesEmulator>),
     GameBoy(Box<NativeGameBoyEmulator>),
-    #[cfg(feature = "unstable-cores")]
-    GameBoyAdvance(Box<jgenesis_native_driver::NativeGbaEmulator>),
+    GameBoyAdvance(Box<NativeGbaEmulator>),
 }
 
 impl GenericEmulator {
@@ -352,7 +351,6 @@ impl GenericEmulator {
             Console::GameBoy | Console::GameBoyColor => {
                 Self::GameBoy(Box::new(jgenesis_native_driver::create_gb(config.gb_config(path))?))
             }
-            #[cfg(feature = "unstable-cores")]
             Console::GameBoyAdvance => Self::GameBoyAdvance(Box::new(
                 jgenesis_native_driver::create_gba(config.gba_config(path))?,
             )),
@@ -403,7 +401,6 @@ impl GenericEmulator {
             Self::Nes(emulator) => emulator.reload_nes_config(config.nes_config(path)),
             Self::Snes(emulator) => emulator.reload_snes_config(config.snes_config(path)),
             Self::GameBoy(emulator) => emulator.reload_gb_config(config.gb_config(path)),
-            #[cfg(feature = "unstable-cores")]
             Self::GameBoyAdvance(emulator) => emulator.reload_gba_config(config.gba_config(path)),
         }
     }

--- a/frontend/jgenesis-native-config/Cargo.toml
+++ b/frontend/jgenesis-native-config/Cargo.toml
@@ -6,14 +6,13 @@ edition = "2024"
 [features]
 default = []
 clap = ["dep:clap"]
-gba = ["dep:gba-config"]
 
 [dependencies]
 jgenesis-common = { path = "../../common/jgenesis-common", features = ["serde"] }
 jgenesis-proc-macros = { path = "../../common/jgenesis-proc-macros" }
 
 gb-config = { path = "../../config/gb-config", features = ["serde"] }
-gba-config = { path = "../../config/gba-config", features = ["serde"], optional = true }
+gba-config = { path = "../../config/gba-config", features = ["serde"] }
 genesis-config = { path = "../../config/genesis-config", features = ["serde"] }
 nes-config = { path = "../../config/nes-config", features = ["serde"] }
 smsgg-config = { path = "../../config/smsgg-config", features = ["serde"] }

--- a/frontend/jgenesis-native-config/src/common.rs
+++ b/frontend/jgenesis-native-config/src/common.rs
@@ -39,9 +39,7 @@ impl WindowSize {
     const GB_HEIGHT: f64 = 144.0;
     const GB_WIDTH: f64 = 160.0;
 
-    #[cfg(feature = "gba")]
     const GBA_HEIGHT: f64 = 160.0;
-    #[cfg(feature = "gba")]
     const GBA_WIDTH: f64 = 240.0;
 
     #[must_use]
@@ -154,7 +152,6 @@ impl WindowSize {
         Self::new(Self::GB_WIDTH, Self::GB_HEIGHT, size)
     }
 
-    #[cfg(feature = "gba")]
     #[must_use]
     pub fn new_gba(size: NonZeroU8) -> Self {
         Self::new(Self::GBA_WIDTH, Self::GBA_HEIGHT, size)

--- a/frontend/jgenesis-native-config/src/gba.rs
+++ b/frontend/jgenesis-native-config/src/gba.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "gba")]
-
 use gba_config::{GbaAspectRatio, GbaColorCorrection, GbaSaveMemory};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;

--- a/frontend/jgenesis-native-config/src/input.rs
+++ b/frontend/jgenesis-native-config/src/input.rs
@@ -283,7 +283,6 @@ pub struct InputAppConfig {
     pub snes: SnesInputConfig,
     #[serde(default)]
     pub game_boy: GameBoyInputConfig,
-    #[cfg(feature = "gba")]
     #[serde(default)]
     pub game_boy_advance: mappings::GbaInputConfig,
     #[serde(default)]

--- a/frontend/jgenesis-native-config/src/input/mappings.rs
+++ b/frontend/jgenesis-native-config/src/input/mappings.rs
@@ -1,6 +1,5 @@
 use crate::input::{GenericInput, Hotkey};
 use gb_config::GameBoyButton;
-#[cfg(feature = "gba")]
 use gba_config::GbaButton;
 use genesis_config::{GenesisButton, GenesisControllerType};
 use jgenesis_common::input::Player;
@@ -643,7 +642,6 @@ impl Default for GameBoyInputConfig {
     }
 }
 
-#[cfg(feature = "gba")]
 define_controller_mapping!(GbaInputMapping, GbaButton, [
     up: Up,
     left: Left,
@@ -657,7 +655,6 @@ define_controller_mapping!(GbaInputMapping, GbaButton, [
     select: Select,
 ]);
 
-#[cfg(feature = "gba")]
 impl GbaInputMapping {
     #[must_use]
     pub fn keyboard_arrows() -> Self {
@@ -692,7 +689,6 @@ impl GbaInputMapping {
     }
 }
 
-#[cfg(feature = "gba")]
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ConfigDisplay)]
 pub struct GbaInputConfig {
     #[serde(default = "default_gba_mapping_1")]
@@ -703,7 +699,6 @@ pub struct GbaInputConfig {
     pub mapping_2: GbaInputMapping,
 }
 
-#[cfg(feature = "gba")]
 impl GbaInputConfig {
     #[must_use]
     pub fn to_mapping_vec(&self) -> ButtonMappingVec<'_, GbaButton> {
@@ -716,12 +711,10 @@ impl GbaInputConfig {
     }
 }
 
-#[cfg(feature = "gba")]
 fn default_gba_mapping_1() -> GbaInputMapping {
     GbaInputMapping::keyboard_arrows()
 }
 
-#[cfg(feature = "gba")]
 impl Default for GbaInputConfig {
     fn default() -> Self {
         Self { mapping_1: default_gba_mapping_1(), mapping_2: GbaInputMapping::default() }

--- a/frontend/jgenesis-native-config/src/lib.rs
+++ b/frontend/jgenesis-native-config/src/lib.rs
@@ -12,6 +12,7 @@ pub use migration::{current_config_version, migrate_config};
 
 use crate::common::CommonAppConfig;
 use crate::gb::GameBoyAppConfig;
+use crate::gba::GameBoyAdvanceAppConfig;
 use crate::genesis::{GenesisAppConfig, Sega32XAppConfig, SegaCdAppConfig};
 use crate::input::InputAppConfig;
 use crate::nes::NesAppConfig;
@@ -45,7 +46,6 @@ pub struct ListFilters {
     pub game_boy: bool,
     #[serde(default = "true_fn")]
     pub game_boy_color: bool,
-    #[cfg(feature = "gba")]
     #[serde(default = "true_fn")]
     pub game_boy_advance: bool,
 }
@@ -94,9 +94,8 @@ pub struct AppConfig {
     pub snes: SnesAppConfig,
     #[serde(default)]
     pub game_boy: GameBoyAppConfig,
-    #[cfg(feature = "gba")]
     #[serde(default)]
-    pub game_boy_advance: gba::GameBoyAdvanceAppConfig,
+    pub game_boy_advance: GameBoyAdvanceAppConfig,
     #[serde(default)]
     pub input: InputAppConfig,
     // TODO move GUI-specific config/state somewhere else - separate file?

--- a/frontend/jgenesis-native-driver/Cargo.toml
+++ b/frontend/jgenesis-native-driver/Cargo.toml
@@ -8,14 +8,13 @@ edition = "2024"
 [features]
 default = []
 clap = ["dep:clap"]
-gba = ["dep:gba-config", "dep:gba-core", "jgenesis-native-config/gba"]
 
 [dependencies]
 jgenesis-proc-macros = { path = "../../common/jgenesis-proc-macros" }
 jgenesis-common = { path = "../../common/jgenesis-common" }
 
 gb-core = { path = "../../backend/gb-core" }
-gba-core = { path = "../../backend/gba-core", optional = true }
+gba-core = { path = "../../backend/gba-core" }
 genesis-core = { path = "../../backend/genesis-core" }
 nes-core = { path = "../../backend/nes-core" }
 s32x-core = { path = "../../backend/s32x-core" }
@@ -24,7 +23,7 @@ smsgg-core = { path = "../../backend/smsgg-core" }
 snes-core = { path = "../../backend/snes-core" }
 
 gb-config = { path = "../../config/gb-config" }
-gba-config = { path = "../../config/gba-config", optional = true }
+gba-config = { path = "../../config/gba-config" }
 nes-config = { path = "../../config/nes-config" }
 smsgg-config = { path = "../../config/smsgg-config" }
 snes-config = { path = "../../config/snes-config" }

--- a/frontend/jgenesis-native-driver/src/config.rs
+++ b/frontend/jgenesis-native-driver/src/config.rs
@@ -2,6 +2,7 @@ use crate::archive::{ArchiveEntry, ArchiveError};
 use crate::mainloop::NativeEmulatorError;
 use crate::{NativeEmulatorResult, archive, extensions};
 use gb_core::api::GameBoyEmulatorConfig;
+use gba_core::api::GbaEmulatorConfig;
 use genesis_core::GenesisEmulatorConfig;
 use jgenesis_native_config::AppConfig;
 use jgenesis_native_config::common::{
@@ -254,7 +255,6 @@ pub struct GameBoyConfig {
     pub cgb_boot_rom_path: Option<PathBuf>,
 }
 
-#[cfg(feature = "gba")]
 #[derive(Debug, Clone, ConfigDisplay)]
 pub struct GameBoyAdvanceConfig {
     #[cfg_display(indent_nested)]
@@ -292,7 +292,6 @@ pub trait AppConfigExt {
     #[must_use]
     fn gb_config(&self, path: PathBuf) -> Box<GameBoyConfig>;
 
-    #[cfg(feature = "gba")]
     #[must_use]
     fn gba_config(&self, path: PathBuf) -> Box<GameBoyAdvanceConfig>;
 }
@@ -517,10 +516,7 @@ impl AppConfigExt for AppConfig {
         })
     }
 
-    #[cfg(feature = "gba")]
     fn gba_config(&self, path: PathBuf) -> Box<GameBoyAdvanceConfig> {
-        use gba_core::api::GbaEmulatorConfig;
-
         Box::new(GameBoyAdvanceConfig {
             common: self.common_config(path),
             inputs: self.input.game_boy_advance.clone(),

--- a/frontend/jgenesis-native-driver/src/extensions.rs
+++ b/frontend/jgenesis-native-driver/src/extensions.rs
@@ -18,10 +18,7 @@ pub const NES: &[&str] = &["nes"];
 pub const SNES: &[&str] = &["sfc", "smc"];
 pub const GAME_BOY: &[&str] = &["gb"];
 pub const GAME_BOY_COLOR: &[&str] = &["gbc"];
-#[cfg(feature = "gba")]
 pub const GAME_BOY_ADVANCE: &[&str] = &["gba"];
-#[cfg(not(feature = "gba"))]
-pub const GAME_BOY_ADVANCE: &[&str] = &[];
 
 pub const SUPPORTED_ARCHIVES: &[&str] = &["zip", "7z"];
 
@@ -113,7 +110,6 @@ fn build_extension_lookup() -> HashMap<&'static str, Console> {
         (SNES, Console::Snes),
         (GAME_BOY, Console::GameBoy),
         (GAME_BOY_COLOR, Console::GameBoyColor),
-        #[cfg(feature = "gba")]
         (GAME_BOY_ADVANCE, Console::GameBoyAdvance),
     ]
     .into_iter()
@@ -143,7 +139,6 @@ pub enum Console {
     Snes,
     GameBoy,
     GameBoyColor,
-    #[cfg(feature = "gba")]
     GameBoyAdvance,
 }
 
@@ -219,7 +214,6 @@ impl Console {
             Self::Snes => "SNES",
             Self::GameBoy => "Game Boy",
             Self::GameBoyColor => "Game Boy Color",
-            #[cfg(feature = "gba")]
             Self::GameBoyAdvance => "Game Boy Advance",
         }
     }
@@ -235,7 +229,6 @@ impl Console {
             Self::Nes => NES,
             Self::Snes => SNES,
             Self::GameBoy | Self::GameBoyColor => &GB_GBC,
-            #[cfg(feature = "gba")]
             Self::GameBoyAdvance => GAME_BOY_ADVANCE,
         }
     }

--- a/frontend/jgenesis-native-driver/src/lib.rs
+++ b/frontend/jgenesis-native-driver/src/lib.rs
@@ -7,13 +7,11 @@ mod mainloop;
 
 pub use mainloop::{
     AudioError, Native32XEmulator, NativeEmulator, NativeEmulatorError, NativeEmulatorResult,
-    NativeGameBoyEmulator, NativeGenesisEmulator, NativeNesEmulator, NativeSegaCdEmulator,
-    NativeSmsGgEmulator, NativeSnesEmulator, NativeTickEffect, SAVE_STATE_SLOTS, SaveStateMetadata,
-    SaveWriteError, create_32x, create_gb, create_genesis, create_nes, create_sega_cd,
-    create_smsgg, create_snes,
+    NativeGameBoyEmulator, NativeGbaEmulator, NativeGenesisEmulator, NativeNesEmulator,
+    NativeSegaCdEmulator, NativeSmsGgEmulator, NativeSnesEmulator, NativeTickEffect,
+    SAVE_STATE_SLOTS, SaveStateMetadata, SaveWriteError, create_32x, create_gb, create_gba,
+    create_genesis, create_nes, create_sega_cd, create_smsgg, create_snes,
 };
-#[cfg(feature = "gba")]
-pub use mainloop::{NativeGbaEmulator, create_gba};
 use sdl2::VideoSubsystem;
 
 #[must_use]

--- a/frontend/jgenesis-native-driver/src/mainloop.rs
+++ b/frontend/jgenesis-native-driver/src/mainloop.rs
@@ -11,7 +11,6 @@ mod snes;
 mod state;
 
 pub use gb::{NativeGameBoyEmulator, create_gb};
-#[cfg(feature = "gba")]
 pub use gba::{NativeGbaEmulator, create_gba};
 pub use genesis::{
     Native32XEmulator, NativeGenesisEmulator, NativeSegaCdEmulator, create_32x, create_genesis,
@@ -373,15 +372,12 @@ pub enum NativeEmulatorError {
     GbBootRomLoad(io::Error),
     #[error("{0}")]
     GameBoyLoad(#[from] GameBoyLoadError),
-    #[cfg(feature = "gba")]
     #[error("No Game Boy Advance BIOS provided")]
     GbaNoBios,
-    #[cfg(feature = "gba")]
     #[error("Failed to load GBA BIOS: {0}")]
     GbaBiosLoad(io::Error),
-    #[cfg(feature = "gba")]
     #[error("Failed to initialize GBA emulator: {0}")]
-    GbaLoad(#[from] gba_core::api::GbaLoadError),
+    GbaLoad(#[from] GbaLoadError),
     #[error("I/O error opening save state file '{path}': {source}")]
     StateFileOpen {
         path: String,
@@ -888,6 +884,7 @@ macro_rules! bincode_config {
 }
 
 use bincode_config;
+use gba_core::api::GbaLoadError;
 use jgenesis_native_config::common::{FullscreenMode, HideMouseCursor, WindowSize};
 use jgenesis_native_config::input::mappings::ButtonMappingVec;
 use jgenesis_native_config::input::{CompactHotkey, Hotkey};

--- a/frontend/jgenesis-native-driver/src/mainloop/gba.rs
+++ b/frontend/jgenesis-native-driver/src/mainloop/gba.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "gba")]
-
 use crate::config::{GameBoyAdvanceConfig, RomReadResult};
 use crate::mainloop::save::{DeterminedPaths, FsSaveWriter};
 use crate::mainloop::{file_name_no_ext, save};


### PR DESCRIPTION
It's not perfect but I think it's in a decent enough state to remove the compile-time feature gate.

All major hardware components are emulated except for some stuff related to the serial port, which is only stubbed out enough to get a few known problematic games to boot (e.g. Sonic Advance, Digimon Racing)

All types of cartridge save memory are supported, but no cartridge peripherals are emulated except for the Seiko RTC chip used by a few games.

Performance is significantly better when compiled with fat LTOs vs. the standard `--release` profile, which is a little curious. 32X has a similar issue so maybe it's something to do with being able to inline more of the CPU bus implementation.

<img width="480" height="352" alt="mmz2" src="https://github.com/user-attachments/assets/647b5260-d202-4f78-a972-68efb0c755fd" />