### PR TITLE
[GBC] fix hdma length handling on in progress hdma

### DIFF
--- a/backend/gb-core/src/dma.rs
+++ b/backend/gb-core/src/dma.rs
@@ -197,14 +197,16 @@ impl DmaUnit {
         let dma_length = 16 * u16::from((value & 0x7F) + 1);
 
         if self.vram_dma_state != VramDmaState::Idle {
+            // HDMA5 writes can alter the length of an in-progress HDMA
+            // NASCAR 2000 (with bit 7)
+            // liji32/samesuite/dma/hdma_lcd_off and
+            // liji32/samesuite/dma/hdma_mode0 (without bit 7)
+            // depend on this behavior
+            self.vram_dma_length = dma_length;
+
             if !value.bit(7) {
                 // Writing HDMA5 with bit 7 clear while an HDMA is in progress immediately cancels it
                 self.vram_dma_state = VramDmaState::Idle;
-            } else {
-                // HDMA5 writes with bit 7 set can alter the length of an in-progress HDMA
-                // NASCAR 2000 depends on this
-                // TODO does the length also change when bit 7 is clear?
-                self.vram_dma_length = dma_length;
             }
 
             return;


### PR DESCRIPTION
if a hdma is active and a new HDMA5 value is written, length is updated regardless of bit 7. Nascar 2000 depends on it with bit 7, liji32/samesuite dma tests hdma_lcd_off and hdma_mode0 without bit7.

LIJI32/SameSuite
[hdma_lcd_off source](https://github.com/LIJI32/SameSuite/blob/master/dma/hdma_lcd_off.asm)
[hdma_mode0 source](https://github.com/LIJI32/SameSuite/blob/master/dma/hdma_mode0.asm)
[prebuilt versions](https://github.com/c-sp/game-boy-test-roms/releases/tag/v7.0)
